### PR TITLE
Single source of truth: Use KOLIBRI_HOME as set by /etc/default/kolibri

### DIFF
--- a/debian/kolibri-server.init
+++ b/debian/kolibri-server.init
@@ -22,12 +22,21 @@ PIDFILE_UWSGI=/var/run/$NAME/uwsgi.pid
 [ -x "$MAIN" ] || exit 0
 
 # Read configuration variable file if it is present
+[ -r $CONFIG_FILE ] || echo "Configuration not found: $CONFIG_FILE" && exit 1
 [ -r $CONFIG_FILE ] && . $CONFIG_FILE
 
-# I don't like this, what if the user decides to set KOLIBRI_HOME somewhere else?
-DAEMON_HOME="$(getent passwd $KOLIBRI_USER | awk -F ':' '{print $6}')"/.kolibri
-DAEMON_UWSGI_ARGS="--ini /etc/kolibri/kolibri.ini --uid=$KOLIBRI_USER \
-	--env=KOLIBRI_HOME=$DAEMON_HOME --daemonize=$DAEMON_HOME/uwsgi.log --pidfile=$PIDFILE_UWSGI"
+# Check that env vars were set after sourcing $CONFIG_FILE
+[ "$KOLIBRI_USER" == "" ] && echo "$KOLIBRI_USER not set" && exit 1
+[ "$KOLIBRI_HOME" == "" ] && echo "$KOLIBRI_HOME not set" && exit 1
+
+KOLIBRI_USER_HOME="$(getent passwd $KOLIBRI_USER | awk -F ':' '{print $6}')"
+
+DAEMON_UWSGI_ARGS="\
+	--ini /etc/kolibri/kolibri.ini \
+	--uid=$KOLIBRI_USER \
+	--env=KOLIBRI_HOME="$KOLIBRI_HOME" \
+	--daemonize="$KOLIBRI_USER_HOME/uwsgi.log" \
+	--pidfile=$PIDFILE_UWSGI"
 
 # Load the VERBOSE setting and other rcS variables
 . /lib/init/vars.sh


### PR DESCRIPTION
Don't assume the `KOLIBRI_HOME` as it may be differently set in `/etc/kolibri/default`. Note that this file is owned by the `kolibri` dependency, so essentially this package is just doing what other packages prescribe.