### PR TITLE
Fix problem with uwsgi dealing with stream from BytesIO objects

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kolibri-server (0.3.1-0ubuntu1) bionic; urgency=medium
+
+  * Added wsgi-disable-file-wrapper flag to fix uwsgi bug
+
+ -- José L. Redrejo Rodríguez <jredrejo@debian.org>  Mon, 19 Aug 2019 16:57:06 +0200
+
 kolibri-server (0.3.0-0ubuntu1) bionic; urgency=low
 
   * debian/control:

--- a/debian/control
+++ b/debian/control
@@ -10,7 +10,7 @@ Homepage: https://learningequality.org/kolibri
 
 Package: kolibri-server
 Architecture: all
-Depends: kolibri (>= 0.12.6), nginx-full, uwsgi, uwsgi-plugin-python3, redis-server
+Depends: kolibri (>= 0.12.6), nginx-full, uwsgi (>= 2.0.12), uwsgi-plugin-python3, redis-server
 Description: Improve Kolibri server network configuration
  This package automates uwsgi and nginx configuration for
  Kolibri to take all the benefits from the multicore

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -24,6 +24,7 @@ max-requests = 1000 # Reload workers after the specified amount of managed reque
 vacuum = True       # Try to remove all of the generated files/sockets (UNIX sockets and pidfiles) upon exit.
 module =kolibri.deployment.default.wsgi:application
 buffer-size = 8192  # needed to support long requests blocks (in lessons, for example)
+wsgi-disable-file-wrapper = true  # needed to fix uwsgi bug https://github.com/unbit/uwsgi/issues/1126
 
 # algorithm to scale automatically:
 cheaper-algo = spare # set cheaper algorithm to use, if not set default will be used


### PR DESCRIPTION
uwsgi fails to respond a BytesIO stream, this can be workarounded since uwsgi v 2.0.12 wsgi-disable-file-wrapper.

With this PR the problem loading some html5 resources is fixed.

Closes: #24 