### PR TITLE
Ensure kolibri is stopped when stopping kolibri-server

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kolibri-server (0.3.1-0ubuntu2) UNRELEASED; urgency=medium
+
+  * debian/kolibri-server.init: ensure kolibri stops is executed in the right order
+
+ -- José L. Redrejo Rodríguez <jredrejo@debian.org>  Tue, 20 Aug 2019 20:21:16 +0200
+
 kolibri-server (0.3.1-0ubuntu1) bionic; urgency=medium
 
   * Added wsgi-disable-file-wrapper flag to fix uwsgi bug

--- a/debian/kolibri-server.init
+++ b/debian/kolibri-server.init
@@ -102,8 +102,8 @@ do_check_nginx()
 }
 
 do_stop() {
-  do_stop_uwsgi
   service kolibri stop
+  do_stop_uwsgi
 
   retval=$?
 
@@ -144,7 +144,7 @@ case "$1" in
     # 'force-reload' alias
     #
     log_daemon_msg "Restarting $DESC" "$NAME"
-    #do_stop
+    do_stop
     case "$?" in
       0|1)
         if [ -s "$CONFIG_FILE" ]; then


### PR DESCRIPTION
When doing  `service kolibri-server stop` or `service kolibri-server restart` the background kolibri process was not stopped properly because the script didn't wait for `service kolibri stop`to finish.
This PR fixes it to close #20 