### PR TITLE
Cleanup when kolibri-server is uninstalled, ensure kolibri still runs

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,6 @@
 kolibri-server (0.3.2-0ubuntu1) bionic; urgency=medium
 
-  * Added logic to restore CherryPy and junk files when removing this package
+  * Added logic to restore CherryPy and remove junk files when removing this package
 
  -- José L. Redrejo Rodríguez <jredrejo@debian.org>  Wed, 21 Aug 2019 17:33:29 +0200
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,10 @@
-kolibri-server (0.3.1-0ubuntu2) UNRELEASED; urgency=medium
+kolibri-server (0.3.2-0ubuntu1) bionic; urgency=medium
+
+  * Added logic to restore CherryPy and junk files when removing this package
+
+ -- José L. Redrejo Rodríguez <jredrejo@debian.org>  Wed, 21 Aug 2019 17:33:29 +0200
+
+kolibri-server (0.3.1-0ubuntu2) bionic; urgency=medium
 
   * debian/kolibri-server.init: ensure kolibri stops is executed in the right order
 

--- a/debian/postrm
+++ b/debian/postrm
@@ -4,6 +4,9 @@ set -e
 case "$1" in
   remove|purge)
     rm -f /etc/nginx/conf.d/kolibri.conf
+    rm -Rf /etc/kolibri/nginx.d
+    service nginx reload
+    service kolibri restart
     ;;
 
 

--- a/debian/prerm
+++ b/debian/prerm
@@ -1,0 +1,23 @@
+#!/bin/sh
+set -e
+
+case "$1" in
+  remove|purge)
+    # get KOLIBRI_USER from kolibri installer package:
+    . /etc/default/kolibri
+    su $KOLIBRI_USER -c "/usr/share/kolibri-server/kolibri_server_setup.py -c"
+    ;;
+
+
+  upgrade|failed-upgrade|abort-install|abort-upgrade|disappear)
+    ;;
+
+  *)
+    echo "prerm called with unknown argument \`$1'" >&2
+    exit 1
+    ;;
+esac
+
+#DEBHELPER#
+
+exit 0

--- a/kolibri_server_setup.py
+++ b/kolibri_server_setup.py
@@ -66,6 +66,16 @@ def disable_cherrypy():
     """
     update_options_file('Server', "CHERRYPY_START", False, KOLIBRI_HOME)
 
+
+def enable_cherrypy():
+    """
+    Disables internal kolibri web server.
+    Kolibri will only run background tasks.
+    Web must be provided by an external server, usually uwsgi + nginx
+    """
+    update_options_file('Server', "CHERRYPY_START", True, KOLIBRI_HOME)
+
+
 def enable_redis_cache():
     """
     Set redis as the cache backend .
@@ -147,14 +157,25 @@ if __name__ == '__main__':
         default="",
         help="Initial port to be used when installing/reconfiguring kolibri-server package",
     )
+    parser.add_argument(
+        "-c",
+        "--cherrypy",
+        required=False,
+        default=False,
+        action='store_true',
+        help="Restore cherrypy because kolibri-server is not going to be run",
+    )
     args = parser.parse_args()
-    if args.debconfport:  # To be executed only when installing/reconfiguring the Debian package
-        disable_cherrypy()
-        set_port(args.debconfport)
-        enable_redis_cache()
+    if args.cherrypy:
+        enable_cherrypy()
     else:
-        disable_cherrypy()
-        save_nginx_conf_include(STATIC_ROOT)
-        save_nginx_conf_port(port)
-        # Let's update debconf, just in case the user has changed the port in options.ini:
-        set_debconf_port(port)
+        if args.debconfport:  # To be executed only when installing/reconfiguring the Debian package
+            disable_cherrypy()
+            set_port(args.debconfport)
+            enable_redis_cache()
+        else:
+            disable_cherrypy()
+            save_nginx_conf_include(STATIC_ROOT)
+            save_nginx_conf_port(port)
+            # Let's update debconf, just in case the user has changed the port in options.ini:
+            set_debconf_port(port)

--- a/kolibri_server_setup.py
+++ b/kolibri_server_setup.py
@@ -70,7 +70,6 @@ def disable_cherrypy():
 def enable_cherrypy():
     """
     Enable internal kolibri web server.
-    Kolibri will only run normally.
     This option is incompatible with running kolibri-server
     """
     update_options_file('Server', "CHERRYPY_START", True, KOLIBRI_HOME)

--- a/kolibri_server_setup.py
+++ b/kolibri_server_setup.py
@@ -69,9 +69,9 @@ def disable_cherrypy():
 
 def enable_cherrypy():
     """
-    Disables internal kolibri web server.
-    Kolibri will only run background tasks.
-    Web must be provided by an external server, usually uwsgi + nginx
+    Enable internal kolibri web server.
+    Kolibri will only run normally.
+    This option is incompatible with running kolibri-server
     """
     update_options_file('Server', "CHERRYPY_START", True, KOLIBRI_HOME)
 


### PR DESCRIPTION
Several clean up tasks to ensure that removing or purging `kolibri-server` package leaves the system in a good shape, without junk files and with `kolibri` working single threaded with CherryPy.

Closes #29 
Closes #16 