### PR TITLE
Increase serviced timeouts so it works properly in slow devices

### DIFF
--- a/debian/kolibri-server.service
+++ b/debian/kolibri-server.service
@@ -10,7 +10,8 @@ Wants=network-online.target
 Type=forking
 ExecStart=/etc/init.d/kolibri-server start
 ExecStop=/etc/init.d/kolibri-server stop
-TimeoutStopSec=5
+TimeoutStartSec=infinity
+TimeoutStopSec=10
 KillMode=mixed
 
 [Install]


### PR DESCRIPTION
Added an infinite start timeout and increased stop timeout so slow devices don't have problems when starting/stopping the service

Closes: #31 