### PR TITLE
Error 50x styling updates

### DIFF
--- a/nginx_error_page/error.html
+++ b/nginx_error_page/error.html
@@ -4,36 +4,63 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
 
-    <title>Kolibri server has not started</title>
+    <title>Kolibri has not started</title>
 
     <style>
-      body {
-        height: 100%;
+      html, body {
         font-family: noto-full, noto-subset, noto-common, sans-serif;
         color: #212121;
-      }
-      html {
-        height: 90%;
+        margin: 0;
       }
       h1 {
-        display: flex;
-        flex-flow: row;
-        align-items: center;
-        text-align: center;
+        font-size: 24px;
       }
-      .container {
+      p {
+        font-size: 16px;        
+      }
+      a {
+        color: #212121;
+        -webkit-transition: color .25s ease;
+        transition: color .25s ease;
+      }
+      a:hover {
+        color: black;
+      }
+      button {
+        padding: 0 16px;
+        font-size: 14px;
+        font-weight: 700;
+        line-height: 36px;
+        border: 0;
+        border-radius: 2px;
+        color: rgb(33, 33, 33);
+        cursor: pointer;
+        text-transform: uppercase;
+        -webkit-transition: background-color .25s ease;
+        transition: background-color .25s ease;
+      }
+      button:hover {
+        background-color: rgb(238, 238, 238);
+      }
+      .center-outer {
+        display: table;
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
         height: 100%;
-        display: flex;
-        align-items: center;
-        justify-content: center;
-        flex-flow: column;
       }
-      .message {
-        font-size: 1.2em;
+      .center-inner {
+        display: table-cell;
+        vertical-align: middle;
+        text-align: center;
+        position: relative;
+        top: -40px; /* visual weight offset to balance logo */
+        padding: 48px; /* 8px larger than offset */
       }
       .spinner {
         display: inline-block;
-        margin-right: 18px;
+        margin-right: 16px;
       }
       .spinner-svg {
         -webkit-transform-origin: center center;
@@ -51,22 +78,21 @@
         stroke-dashoffset: -35px;
         stroke-linecap: round;
       }
-      .raised {
-        padding: 0 16px;
-        margin: 8px;
-        font-size: 14px;
-        font-weight: 700;
-        line-height: 36px;
-        border: 0;
-        border-radius: 2px;
-        color: rgb(33, 33, 33);
-        background-color: rgb(238, 238, 238);
-        cursor: pointer;
+      .header {
+        position: relative;
+        left: -8px; /* visual weight offset to balance spinner */
+      }
+      .button {
+        margin-top: 24px;
+      }
+      .version {
+        font-size: 12px;
+        color: rgb(97, 97, 97);;
       }
     </style>
   </head>
-  <body>
-    <div class="container">
+  <body class="center-outer">
+    <div class="center-inner">
       <svg
         xmlns="http://www.w3.org/2000/svg"
         width="47"
@@ -363,23 +389,18 @@
         <path stroke="rgba(0,0,0,0.8745098039215686)" d="M18 37h1" />
       </svg>
 
-      <h1>
-        <div class="spinner" style="width: 24px; height: 24px;">
+      <h1 class="header">
+        <div class="spinner" style="width: 18px; height: 18px;">
           <svg class="spinner-svg" viewBox="25 25 50 50">
             <circle class="spinner-circle-path" cx="50" cy="50" fill="none" r="20" stroke-miterlimit="10" stroke-width="4.5"></circle>
           </svg>
         </div>
         Starting Kolibri server
       </h1>
-
-      <p class="message">
-        If you are not redirected in a few minutes, please contact our community forums or try refreshing this page.
-      </p>
-      <div>
-        <a href="https://community.learningequality.org/c/support/kolibri">Ask for help on our community forums</a>
-      </div>
-      <button class="raised" onClick="location.reload();">REFRESH</button>
-      <div>kolibri-server 1.2.3</div>
+      <p class="message">You should be automatically redirected within a few minutes</p>
+      <p><a href="https://community.learningequality.org/c/support/kolibri">If not, please ask for help in our community forums</a></p>
+      <p><button class="button" onClick="location.reload();">Refresh page</button></p>
+      <p class="version">kolibri-server 1.2.3</p>
     </div>
 
     <script>

--- a/nginx_error_page/error.html
+++ b/nginx_error_page/error.html
@@ -32,7 +32,24 @@
         font-size: 1.2em;
       }
       .spinner {
-        stroke: purple;
+        display: inline-block;
+        margin-right: 18px;
+      }
+      .spinner-svg {
+        -webkit-transform-origin: center center;
+        -ms-transform-origin: center center;
+        transform-origin: center center; 
+        -webkit-animation: spinner-animation 1s linear infinite;
+        animation: spinner-animation 1s linear infinite;
+      }
+      @keyframes spinner-animation {
+        100% { transform: rotate(360deg); }
+      }
+      .spinner-circle-path {
+        stroke: #212121;
+        stroke-dasharray: 89, 200;
+        stroke-dashoffset: -35px;
+        stroke-linecap: round;
       }
       .raised {
         padding: 0 16px;
@@ -347,31 +364,12 @@
       </svg>
 
       <h1>
-        <svg
-          width="50"
-          height="30"
-          viewBox="0 0 38 38"
-          xmlns="http://www.w3.org/2000/svg"
-          class="spinner"
-          stroke="#000"
-        >
-          <g fill="none" fill-rule="evenodd">
-            <g transform="translate(1 1)" stroke-width="2">
-              <circle stroke-opacity=".5" cx="18" cy="18" r="18" />
-              <path d="M36 18c0-9.94-8.06-18-18-18">
-                <animateTransform
-                  attributeName="transform"
-                  type="rotate"
-                  from="0 18 18"
-                  to="360 18 18"
-                  dur="1s"
-                  repeatCount="indefinite"
-                />
-              </path>
-            </g>
-          </g>
-        </svg>
-        Starting Kolibri server...
+        <div class="spinner" style="width: 24px; height: 24px;">
+          <svg class="spinner-svg" viewBox="25 25 50 50">
+            <circle class="spinner-circle-path" cx="50" cy="50" fill="none" r="20" stroke-miterlimit="10" stroke-width="4.5"></circle>
+          </svg>
+        </div>
+        Starting Kolibri server
       </h1>
 
       <p class="message">

--- a/nginx_error_page/error.html
+++ b/nginx_error_page/error.html
@@ -2,9 +2,9 @@
 <html>
   <head>
     <meta charset="utf-8" />
-    <title>Error</title>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <!-- <meta http-equiv="refresh" content="2" /> -->
+
+    <title>Kolibri server has not started</title>
 
     <style>
       body {

--- a/nginx_error_page/error.html
+++ b/nginx_error_page/error.html
@@ -6,9 +6,11 @@
 
     <title>Kolibri has not started</title>
 
+    <link href="https://fonts.googleapis.com/css?family=Noto+Sans:400,700&display=swap&subset=cyrillic,cyrillic-ext,devanagari,greek,greek-ext,latin-ext,vietnamese" rel="stylesheet">
+
     <style>
       html, body {
-        font-family: noto-full, noto-subset, noto-common, sans-serif;
+        font-family: 'Noto Sans', sans-serif;
         color: #212121;
         margin: 0;
       }
@@ -28,6 +30,7 @@
       }
       button {
         padding: 0 16px;
+        font-family: 'Noto Sans', sans-serif;
         font-size: 14px;
         font-weight: 700;
         line-height: 36px;


### PR DESCRIPTION
* uses table CSS instead of flexbox
* loads Noto Sans from online API when available; otherwise falls back on `sans-serif`
* updates some language
* lots of visual changes as shown below

| before | after |
|--|--|
|  ![image](https://user-images.githubusercontent.com/2367265/67127058-635a2880-f1ad-11e9-975e-0d15007b1dc6.png)  | ![image](https://user-images.githubusercontent.com/2367265/67126743-b2538e00-f1ac-11e9-9f72-b419c02067f1.png) |

