### PR TITLE
Increase timeout for systemd service stop

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kolibri-server (0.3.7-0ubuntu1) bionic; urgency=medium
+
+  * Increase timeout for systemd service stop action to 90 seconds, related to upgrade issues
+
+ -- Benjamin Bach <benjamin@learningequality.org>  Mon, 13 Jan 2020 16:00:56 +0100
+
 kolibri-server (0.3.6-0ubuntu1) bionic; urgency=medium
 
   * New release with multiple new translations added

--- a/debian/kolibri-server.service
+++ b/debian/kolibri-server.service
@@ -11,7 +11,7 @@ Type=forking
 ExecStart=/etc/init.d/kolibri-server start
 ExecStop=/etc/init.d/kolibri-server stop
 TimeoutStartSec=infinity
-TimeoutStopSec=10
+TimeoutStopSec=90
 KillMode=mixed
 
 [Install]


### PR DESCRIPTION
Increase timeout for systemd service stop, related to upgrade issues on Raspberry Pi

Fixes #31 