### PR TITLE
logrotate rule, updated log path, fixed potential issue in init.d service

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,11 @@
+kolibri-server (0.3.8-0ubuntu1) bionic; urgency=medium
+
+  * Log to ~/.kolibri/logs/uwsgi.log
+  * Fix some syntax issues in init.d script
+  * Use bash for init.d script
+
+ -- Benjamin Bach <benjamin@learningequality.org>  Fri, 13 March 2020 15:14:31 +0100
+
 kolibri-server (0.3.7~beta1-0ubuntu4) UNRELEASED; urgency=medium
 
   * Build kolibri-server as a native package

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-kolibri-server (0.3.8-0ubuntu1) bionic; urgency=medium
+kolibri-server (0.4.0-0ubuntu1) UNRELEASED; urgency=medium
 
   * Log to ~/.kolibri/logs/uwsgi.log
   * Adds a logrotate rule in /etc/logrotate.d/kolibri

--- a/debian/changelog
+++ b/debian/changelog
@@ -4,6 +4,7 @@ kolibri-server (0.4.0-0ubuntu1) UNRELEASED; urgency=medium
   * Adds a logrotate rule in /etc/logrotate.d/kolibri
   * Fix some syntax issues in init.d script
   * Use bash for init.d script
+  * Set GID of UWSGI process to same as UID's primary group
 
  -- Benjamin Bach <benjamin@learningequality.org>  Thu, 19 Mar 2020 12:07:10 +0100
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,11 @@
 kolibri-server (0.3.8-0ubuntu1) bionic; urgency=medium
 
   * Log to ~/.kolibri/logs/uwsgi.log
+  * Adds a logrotate rule in /etc/logrotate.d/kolibri
   * Fix some syntax issues in init.d script
   * Use bash for init.d script
 
- -- Benjamin Bach <benjamin@learningequality.org>  Fri, 13 March 2020 15:14:31 +0100
+ -- Benjamin Bach <benjamin@learningequality.org>  Thu, 19 Mar 2020 12:07:10 +0100
 
 kolibri-server (0.3.7~beta1-0ubuntu4) UNRELEASED; urgency=medium
 

--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,6 @@ Package: kolibri-server
 Architecture: all
 Recommends: anacron
 Depends: kolibri (>= 0.12.6), nginx-full, uwsgi (>= 2.0.12), uwsgi-plugin-python3, redis-server (>=4.0), python3 (>= 3.4)
-Pre-Depends: bash
 Enhances: kolibri
 Description: Improve Kolibri server network configuration
  This package automates uwsgi and nginx configuration for

--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Homepage: https://learningequality.org/kolibri
 Package: kolibri-server
 Architecture: all
 Recommends: anacron
-Depends: kolibri (>= 0.12.6), nginx-full, uwsgi (>= 2.0.12), uwsgi-plugin-python3, redis-server (>=4.0)
+Depends: kolibri (>= 0.12.6), nginx-full, uwsgi (>= 2.0.12), uwsgi-plugin-python3, redis-server (>=4.0), python3 (>= 3.4)
 Pre-Depends: bash
 Enhances: kolibri
 Description: Improve Kolibri server network configuration

--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Homepage: https://learningequality.org/kolibri
 Package: kolibri-server
 Architecture: all
 Recommends: anacron
-Depends: kolibri (>= 0.12.6), nginx-full, uwsgi (>= 2.0.12), uwsgi-plugin-python3, redis-server (>=4.0), python3 (>= 3.4)
+Depends: kolibri (>= 0.12.6), nginx-full, uwsgi (>= 2.0.12), uwsgi-plugin-python3, redis-server (>=4.0), python3 (>= 3.0)
 Enhances: kolibri
 Description: Improve Kolibri server network configuration
  This package automates uwsgi and nginx configuration for

--- a/debian/control
+++ b/debian/control
@@ -10,8 +10,10 @@ Homepage: https://learningequality.org/kolibri
 
 Package: kolibri-server
 Architecture: all
-Depends: kolibri (>= 0.12.6), nginx-full, uwsgi (>= 2.0.12), uwsgi-plugin-python3, redis-server (>=4.0)
 Recommends: anacron
+Depends: kolibri (>= 0.12.6), nginx-full, uwsgi (>= 2.0.12), uwsgi-plugin-python3, redis-server (>=4.0)
+Pre-Depends: bash
+Enhances: kolibri
 Description: Improve Kolibri server network configuration
  This package automates uwsgi and nginx configuration for
  Kolibri to take all the benefits from the multicore

--- a/debian/kolibri-server.init
+++ b/debian/kolibri-server.init
@@ -41,10 +41,12 @@ fi
 
 KOLIBRI_USER_HOME="$(getent passwd $KOLIBRI_USER | awk -F ':' '{print $6}')"
 
+KOLIBRI_GID=`id -g $KOLIBRI_USER`
+
 # Expands ~ in the KOLIBRI_HOME to the KOLIBRI_USER's HOME
 KOLIBRI_HOME=${KOLIBRI_HOME//\~/"$KOLIBRI_USER_HOME"}
 
-DAEMON_UWSGI_ARGS="--ini /etc/kolibri/dist/uwsgi.ini --uid=$KOLIBRI_USER \
+DAEMON_UWSGI_ARGS="--ini /etc/kolibri/dist/uwsgi.ini --uid=$KOLIBRI_USER --gid=$KOLIBRI_GID \
   --env=KOLIBRI_HOME=$KOLIBRI_HOME --daemonize=$KOLIBRI_HOME/logs/uwsgi.log --pidfile=$PIDFILE_UWSGI \
   --logfile-chown"
 

--- a/debian/kolibri-server.init
+++ b/debian/kolibri-server.init
@@ -39,12 +39,7 @@ fi
 [ "$KOLIBRI_USER"=="" ] || { echo "$KOLIBRI_USER not set" && exit 1 ;}
 [ "$KOLIBRI_HOME"=="" ] || { echo "$KOLIBRI_HOME not set" && exit 1 ;}
 
-KOLIBRI_USER_HOME="$(getent passwd $KOLIBRI_USER | awk -F ':' '{print $6}')"
-
 KOLIBRI_GID=`id -g $KOLIBRI_USER`
-
-# Expands ~ in the KOLIBRI_HOME to the KOLIBRI_USER's HOME
-KOLIBRI_HOME=${KOLIBRI_HOME//\~/"$KOLIBRI_USER_HOME"}
 
 DAEMON_UWSGI_ARGS="--ini /etc/kolibri/dist/uwsgi.ini --uid=$KOLIBRI_USER --gid=$KOLIBRI_GID \
   --env=KOLIBRI_HOME=$KOLIBRI_HOME --daemonize=$KOLIBRI_HOME/logs/uwsgi.log --pidfile=$PIDFILE_UWSGI \

--- a/debian/kolibri-server.init
+++ b/debian/kolibri-server.init
@@ -45,7 +45,8 @@ KOLIBRI_USER_HOME="$(getent passwd $KOLIBRI_USER | awk -F ':' '{print $6}')"
 KOLIBRI_HOME=${KOLIBRI_HOME//\~/"$KOLIBRI_USER_HOME"}
 
 DAEMON_UWSGI_ARGS="--ini /etc/kolibri/dist/uwsgi.ini --uid=$KOLIBRI_USER \
-  --env=KOLIBRI_HOME=$KOLIBRI_HOME --daemonize=$KOLIBRI_HOME/logs/uwsgi.log --pidfile=$PIDFILE_UWSGI"
+  --env=KOLIBRI_HOME=$KOLIBRI_HOME --daemonize=$KOLIBRI_HOME/logs/uwsgi.log --pidfile=$PIDFILE_UWSGI \
+  --logfile-chown"
 
 # Load the VERBOSE setting and other rcS variables
 . /lib/init/vars.sh

--- a/debian/kolibri-server.init
+++ b/debian/kolibri-server.init
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 ### BEGIN INIT INFO
 # Provides:          kolibri-server
 # Required-Start:    $local_fs $network $remote_fs $syslog $named nginx
@@ -41,11 +41,11 @@ fi
 
 KOLIBRI_USER_HOME="$(getent passwd $KOLIBRI_USER | awk -F ':' '{print $6}')"
 
-# I don't like this, what if the user decides to set KOLIBRI_HOME somewhere else?
-DAEMON_HOME="$KOLIBRI_USER_HOME/.kolibri"
+# Expands ~ in the KOLIBRI_HOME to the KOLIBRI_USER's HOME
+KOLIBRI_HOME=${KOLIBRI_HOME//\~/"$KOLIBRI_USER_HOME"}
 
 DAEMON_UWSGI_ARGS="--ini /etc/kolibri/dist/uwsgi.ini --uid=$KOLIBRI_USER \
-  --env=KOLIBRI_HOME=$DAEMON_HOME --daemonize=$DAEMON_HOME/uwsgi.log --pidfile=$PIDFILE_UWSGI"
+  --env=KOLIBRI_HOME=$KOLIBRI_HOME --daemonize=$KOLIBRI_HOME/logs/uwsgi.log --pidfile=$PIDFILE_UWSGI"
 
 # Load the VERBOSE setting and other rcS variables
 . /lib/init/vars.sh
@@ -131,7 +131,7 @@ case "$1" in
       esac
       service nginx reload
     else
-      [ "$VERBOSE" != no ] && log_warning_msg "$NAME daemon not configured, not starting... (run $SETUP)"
+      [ "$VERBOSE" != no ] && log_warning_msg "$NAME daemon not configured, not starting... \(run $SETUP\)"
     fi
   ;;
   stop)
@@ -163,7 +163,7 @@ case "$1" in
           *) log_end_msg 1 ;; # Failed to start
         esac
         else
-            [ "$VERBOSE" != no ] && log_warning_msg "$NAME daemon not configured, not starting... (run $SETUP)"
+            [ "$VERBOSE" != no ] && log_warning_msg "$NAME daemon not configured, not starting... \(run $SETUP\)"
         fi
     ;;
     *)
@@ -177,5 +177,3 @@ case "$1" in
     exit 3
   ;;
 esac
-
-:

--- a/debian/postinst
+++ b/debian/postinst
@@ -13,9 +13,6 @@ case "$1" in
     # perhaps some day the group name will be set by the kolibri package
     KOLIBRI_GROUP=`id $KOLIBRI_USER -gn`
 
-    KOLIBRI_USER_HOME="$(getent passwd $KOLIBRI_USER | awk -F ':' '{print $6}')"
-    DAEMON_HOME="$KOLIBRI_USER_HOME/.kolibri"
-
     # to avoid problems with previous installations of kolibri-server beta versions:
     rm -f /etc/kolibri/nginx.d/port.conf
 
@@ -31,14 +28,14 @@ case "$1" in
         ln -s /etc/nginx/sites-available/default /etc/nginx/sites-enabled/default
         rm -f /etc/kolibri/nginx_default
     fi
-    echo "include $DAEMON_HOME/nginx.conf;" > /etc/kolibri/nginx.d/099-user.conf
+    echo "include $KOLIBRI_HOME/nginx.conf;" > /etc/kolibri/nginx.d/099-user.conf
 
     # Write logrotate configuration if it's not already written
     LOGROTATE_CONF="/etc/logrotate.d/kolibri"
     if [ -e "/etc/logrotate.d" ] # && ! [ -e "$LOGROTATE_CONF" ]
     then
       # Issues with string substitution for "\n" caused this pattern
-      echo "\"${DAEMON_HOME}/logs/uwsgi/*.log\" {" > "$LOGROTATE_CONF"
+      echo "\"${KOLIBRI_HOME}/logs/uwsgi/*.log\" {" > "$LOGROTATE_CONF"
       echo "  copytruncate" >> "$LOGROTATE_CONF"
       echo "  daily" >> "$LOGROTATE_CONF"
       echo "  rotate 5" >> "$LOGROTATE_CONF"

--- a/debian/postinst
+++ b/debian/postinst
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
 . /usr/share/debconf/confmodule
@@ -28,9 +28,27 @@ case "$1" in
         rm -f /etc/kolibri/nginx_default
     fi
     echo "include $DAEMON_HOME/nginx.conf;" > /etc/kolibri/nginx.d/099-user.conf
+
+    # Write logrotate configuration if it's not already written
+    LOGROTATE_CONF="/etc/logrotate.d/kolibri"
+    if [ -e "/etc/logrotate.d" ] # && ! [ -e "$LOGROTATE_CONF" ]
+    then
+      # Issues with string substitution for "\n" caused this pattern
+      echo "\"${DAEMON_HOME}/logs/uwsgi/*.log\" {" > "$LOGROTATE_CONF"
+      echo "  copytruncate" >> "$LOGROTATE_CONF"
+      echo "  daily" >> "$LOGROTATE_CONF"
+      echo "  rotate 5" >> "$LOGROTATE_CONF"
+      echo "  compress" >> "$LOGROTATE_CONF"
+      echo "  delaycompress" >> "$LOGROTATE_CONF"
+      echo "  missingok" >> "$LOGROTATE_CONF"
+      echo "  notifempty" >> "$LOGROTATE_CONF"
+      echo "}" >> "$LOGROTATE_CONF"
+    fi
+
     service nginx reload || true
     service kolibri-server force-reload || true
     ;;
+
   abort-upgrade|abort-remove|abort-deconfigure)
     ;;
 

--- a/debian/postinst
+++ b/debian/postinst
@@ -9,6 +9,10 @@ case "$1" in
 
     # get KOLIBRI_USER from kolibri installer package:
     . /etc/default/kolibri
+
+    # perhaps some day the group name will be set by the kolibri package
+    KOLIBRI_GROUP=`id $KOLIBRI_USER -gn`
+
     KOLIBRI_USER_HOME="$(getent passwd $KOLIBRI_USER | awk -F ':' '{print $6}')"
     DAEMON_HOME="$KOLIBRI_USER_HOME/.kolibri"
 
@@ -42,6 +46,7 @@ case "$1" in
       echo "  delaycompress" >> "$LOGROTATE_CONF"
       echo "  missingok" >> "$LOGROTATE_CONF"
       echo "  notifempty" >> "$LOGROTATE_CONF"
+      echo "  create 0644 $KOLIBRI_USER $KOLIBRI_GROUP" >> "$LOGROTATE_CONF"
       echo "}" >> "$LOGROTATE_CONF"
     fi
 

--- a/debian/postinst
+++ b/debian/postinst
@@ -35,10 +35,11 @@ case "$1" in
     if [ -e "/etc/logrotate.d" ] # && ! [ -e "$LOGROTATE_CONF" ]
     then
       # Issues with string substitution for "\n" caused this pattern
-      echo "\"${KOLIBRI_HOME}/logs/uwsgi/*.log\" {" > "$LOGROTATE_CONF"
+      echo "\"${KOLIBRI_HOME}/logs/uwsgi.log\" {" > "$LOGROTATE_CONF"
       echo "  copytruncate" >> "$LOGROTATE_CONF"
-      echo "  daily" >> "$LOGROTATE_CONF"
-      echo "  rotate 5" >> "$LOGROTATE_CONF"
+      echo "  weekly" >> "$LOGROTATE_CONF"
+      echo "  rotate 150" >> "$LOGROTATE_CONF"
+      echo "  size 2M" >> "$LOGROTATE_CONF"
       echo "  compress" >> "$LOGROTATE_CONF"
       echo "  delaycompress" >> "$LOGROTATE_CONF"
       echo "  missingok" >> "$LOGROTATE_CONF"

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -6,6 +6,7 @@
 # https://www.techatbloomberg.com/blog/configuring-uwsgi-production-deployment/
 socket = /tmp/kolibri_uwsgi.sock
 chmod-socket = 660
+chown-socket = $(KOLIBRI_USER):www-data
 chdir = /usr/lib/python3/dist-packages/
 pythonpath = /usr/lib/python3/dist-packages/kolibri/dist
 master = true    # https://uwsgi-docs.readthedocs.io/en/latest/Glossary.html?highlight=master

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -6,7 +6,6 @@
 # https://www.techatbloomberg.com/blog/configuring-uwsgi-production-deployment/
 socket = /tmp/kolibri_uwsgi.sock
 chmod-socket = 660
-gid = www-data
 chdir = /usr/lib/python3/dist-packages/
 pythonpath = /usr/lib/python3/dist-packages/kolibri/dist
 master = true    # https://uwsgi-docs.readthedocs.io/en/latest/Glossary.html?highlight=master


### PR DESCRIPTION
* [x] New log path Fixes #49 
* [x] Log rotation Fixes #56
* [x] Bash instead of sh in init.d service
* [x] Fix ownership of UWSGI log
* [x] GID is the same as UID's primary group

~Should add bash to `depends`?~ **No**, it's in essentials