### PR TITLE
Reduce kolibri-server starting/stopping times

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,15 @@
-kolibri-server (0.3.7-0ubuntu1) UNRELEASED; urgency=medium
+kolibri-server (0.3.7~beta1-0ubuntu1) bionic; urgency=medium
 
+  [ José L. Redrejo Rodríguez ]
   * Purge infinitely growing in-memory redis cache with a weekly cronjob and upon restarting Kolibri
+  * Optimizations to system service https://github.com/learningequality/kolibri-server/pull/54
+  * Better guarantees for removing pid and sockets https://github.com/learningequality/kolibri-server/pull/54
+  * Changes to UWSGI configuration https://github.com/learningequality/kolibri-server/pull/54
 
- -- José L. Redrejo Rodríguez <jredrejo@debian.org>  Tue, 25 Feb 2020 10:24:26 +0100
+  [ Benjamin Bach ]
+  * Changes to manual build workflow
+
+ -- Benjamin Bach <benjamin@learningequality.org>  Thu, 26 Mar 2020 11:07:48 +0100
 
 kolibri-server (0.3.6-0ubuntu1) bionic; urgency=medium
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kolibri-server (0.3.7~beta1-0ubuntu2) bionic; urgency=medium
+
+  * Use runuser instead of su (potential systemd issue) #54
+
+ -- Benjamin Bach <benjamin@learningequality.org>  Tue, 14 Apr 2020 12:41:39 +0200
+
 kolibri-server (0.3.7~beta1-0ubuntu1) bionic; urgency=medium
 
   [ José L. Redrejo Rodríguez ]

--- a/debian/kolibri-server.init
+++ b/debian/kolibri-server.init
@@ -54,11 +54,10 @@ do_start()
   # upgrade nginx and kolibri configurations:
   su $KOLIBRI_USER -c "/usr/share/kolibri-server/kolibri_server_setup.py"
   # ensure kolibri application is running:
-  service kolibri start
   do_check_nginx
+  su $KOLIBRI_USER -c "$KOLIBRI_COMMAND start &" 
   mkdir -p /var/run/$NAME
   chown "$KOLIBRI_USER" /var/run/$NAME
-  sleep 15 # ugly hack to avoid race condition when kolibri does vacuum
   start-stop-daemon --start --quiet --pidfile $PIDFILE_UWSGI --exec $DAEMON_UWSGI --test -- $DAEMON_UWSGI_ARGS > /dev/null \
     || return 1
   start-stop-daemon --start --quiet --pidfile $PIDFILE_UWSGI --exec $DAEMON_UWSGI -- \
@@ -94,7 +93,7 @@ do_check_nginx()
   service nginx status 1>/dev/null 2>&1
   retval=$?
   if [ $retval -ne 0  ]; then
-    service kolibri restart
+    su $KOLIBRI_USER -c "$KOLIBRI_COMMAND restart &" 
     service nginx start
   else
     service nginx reload
@@ -102,11 +101,12 @@ do_check_nginx()
 }
 
 do_stop() {
-  service kolibri stop
+  su $KOLIBRI_USER -c "$KOLIBRI_COMMAND stop &"
   do_stop_uwsgi
 
   retval=$?
-
+  rm -f $PIDFILE_UWSGI
+  rm -f /tmp/kolibri_uwsgi.sock
   [ $retval -eq 0 ]
   return $retval
 }

--- a/debian/kolibri-server.init
+++ b/debian/kolibri-server.init
@@ -21,6 +21,16 @@ PIDFILE_UWSGI=/var/run/$NAME/uwsgi.pid
 # Exit if the package is not installed
 [ -x "$MAIN" ] || exit 0
 
+# Prefer runuser over su
+# See: https://github.com/learningequality/kolibri-installer-debian/issues/90
+# Check if runuser exists - it doesn't on 14.04
+if which runuser > /dev/null
+then
+  SU_COMMAND="runuser"
+else
+  SU_COMMAND="su"
+fi
+
 # Read configuration variable file if it is present
 [ -r $CONFIG_FILE ] || { echo "Configuration not found: $CONFIG_FILE" && exit 1 ;}
 [ -r $CONFIG_FILE ] && . $CONFIG_FILE
@@ -52,7 +62,7 @@ do_start()
   #   1 if daemon was already running
   #   2 if daemon could not be started
   # upgrade nginx and kolibri configurations:
-  su $KOLIBRI_USER -c "/usr/share/kolibri-server/kolibri_server_setup.py"
+  $SU_COMMAND $KOLIBRI_USER -c "/usr/share/kolibri-server/kolibri_server_setup.py"
   # ensure kolibri application is running:
   do_check_nginx
   su $KOLIBRI_USER -c "$KOLIBRI_COMMAND start &"

--- a/debian/kolibri-server.init
+++ b/debian/kolibri-server.init
@@ -88,9 +88,10 @@ do_stop_uwsgi()
   #   other if a failure occurred
   start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE_UWSGI --name uwsgi
   RETVAL="$?"
-  [ "$RETVAL" = 2 ] && return 2
   # Many daemons don't delete their pidfiles when they exit.
   rm -f $PIDFILE_UWSGI
+  rm -f /tmp/kolibri_uwsgi.sock
+  [ "$RETVAL" = 2 ] && return 2
   return 0
 }
 
@@ -115,8 +116,6 @@ do_stop() {
   do_stop_uwsgi
 
   retval=$?
-  rm -f $PIDFILE_UWSGI
-  rm -f /tmp/kolibri_uwsgi.sock
   [ $retval -eq 0 ]
   return $retval
 }

--- a/debian/kolibri-server.init
+++ b/debian/kolibri-server.init
@@ -65,7 +65,7 @@ do_start()
   $SU_COMMAND $KOLIBRI_USER -c "/usr/share/kolibri-server/kolibri_server_setup.py"
   # ensure kolibri application is running:
   do_check_nginx
-  su $KOLIBRI_USER -c "$KOLIBRI_COMMAND start &"
+  $SU_COMMAND $KOLIBRI_USER -c "$KOLIBRI_COMMAND start &"
   mkdir -p /var/run/$NAME
   chown "$KOLIBRI_USER" /var/run/$NAME
   start-stop-daemon --start --quiet --pidfile $PIDFILE_UWSGI --exec $DAEMON_UWSGI --test -- $DAEMON_UWSGI_ARGS > /dev/null \
@@ -103,7 +103,7 @@ do_check_nginx()
   service nginx status 1>/dev/null 2>&1
   retval=$?
   if [ $retval -ne 0  ]; then
-    su $KOLIBRI_USER -c "$KOLIBRI_COMMAND restart"
+    $SU_COMMAND $KOLIBRI_USER -c "$KOLIBRI_COMMAND restart"
     service nginx start
   else
     service nginx reload
@@ -111,7 +111,7 @@ do_check_nginx()
 }
 
 do_stop() {
-  su $KOLIBRI_USER -c "$KOLIBRI_COMMAND stop"
+  $SU_COMMAND $KOLIBRI_USER -c "$KOLIBRI_COMMAND stop"
   do_stop_uwsgi
 
   retval=$?

--- a/debian/kolibri-server.init
+++ b/debian/kolibri-server.init
@@ -55,7 +55,7 @@ do_start()
   su $KOLIBRI_USER -c "/usr/share/kolibri-server/kolibri_server_setup.py"
   # ensure kolibri application is running:
   do_check_nginx
-  su $KOLIBRI_USER -c "$KOLIBRI_COMMAND start &" 
+  su $KOLIBRI_USER -c "$KOLIBRI_COMMAND start &"
   mkdir -p /var/run/$NAME
   chown "$KOLIBRI_USER" /var/run/$NAME
   start-stop-daemon --start --quiet --pidfile $PIDFILE_UWSGI --exec $DAEMON_UWSGI --test -- $DAEMON_UWSGI_ARGS > /dev/null \
@@ -93,7 +93,7 @@ do_check_nginx()
   service nginx status 1>/dev/null 2>&1
   retval=$?
   if [ $retval -ne 0  ]; then
-    su $KOLIBRI_USER -c "$KOLIBRI_COMMAND restart &" 
+    su $KOLIBRI_USER -c "$KOLIBRI_COMMAND restart"
     service nginx start
   else
     service nginx reload
@@ -101,7 +101,7 @@ do_check_nginx()
 }
 
 do_stop() {
-  su $KOLIBRI_USER -c "$KOLIBRI_COMMAND stop &"
+  su $KOLIBRI_USER -c "$KOLIBRI_COMMAND stop"
   do_stop_uwsgi
 
   retval=$?

--- a/debian/kolibri-server.init
+++ b/debian/kolibri-server.init
@@ -116,7 +116,6 @@ do_stop() {
   do_stop_uwsgi
 
   retval=$?
-  [ $retval -eq 0 ]
   return $retval
 }
 

--- a/debian/kolibri-server.service
+++ b/debian/kolibri-server.service
@@ -10,12 +10,7 @@ Wants=network-online.target
 Type=forking
 ExecStart=/etc/init.d/kolibri-server start
 ExecStop=/etc/init.d/kolibri-server stop
-TimeoutStartSec=infinity
-TimeoutStopSec=10
 KillMode=mixed
 
 [Install]
 WantedBy=multi-user.target
-
-[Timer]
-OnStartupSec=20

--- a/ppa-copy-packages.py
+++ b/ppa-copy-packages.py
@@ -30,7 +30,7 @@ from launchpadlib.launchpad import Launchpad
 
 PPA_OWNER = 'learningequality'
 PPA_NAME = 'kolibri-proposed'
-PACKAGE_WHITELIST = ['kolibri-server-source']
+PACKAGE_WHITELIST = ['kolibri-server']
 
 SOURCE_SERIES = 'bionic'
 TARGET_SERIESES = ['xenial', 'bionic', 'disco', 'eoan']

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -3,7 +3,7 @@
 # https://uwsgi-docs.readthedocs.io/en/latest/Options.html
 # https://uwsgi-docs.readthedocs.io/en/latest/ThingsToKnow.html
 # https://www.reddit.com/r/Python/comments/4s40ge/understanding_uwsgi_threads_processes_and_gil/
-
+# https://www.techatbloomberg.com/blog/configuring-uwsgi-production-deployment/
 socket = /tmp/kolibri_uwsgi.sock
 chmod-socket = 660
 gid = www-data
@@ -14,7 +14,7 @@ harakiri = 5000  # https://uwsgi-docs.readthedocs.io/en/latest/FAQ.html#what-is-
 enable-threads = true
 cpu-affinity = 1    # Set the number of cores (CPUs) to allocate to each worker process
 listen = 100        # Set the socket listen queue size. When this queue is full, requests will be rejected.
-rawrouter-buffer-size = 16392  # set internal buffer size
+# rawrouter-buffer-size = 16392  # set internal buffer size
 limit-as = 1024      # limit processes address space/vsz
 reload-on-rss = 512 # reload if rss memory is higher than specified megabytes
 no-orphans = true   # automatically kill workers if master dies
@@ -25,6 +25,19 @@ vacuum = True       # Try to remove all of the generated files/sockets (UNIX soc
 module =kolibri.deployment.default.wsgi:application
 buffer-size = 8192  # needed to support long requests blocks (in lessons, for example)
 wsgi-disable-file-wrapper = true  # needed to fix uwsgi bug https://github.com/unbit/uwsgi/issues/1126
+single-interpreter = true
+die-on-term = true                   ; Shutdown when receiving SIGTERM (default is respawn)
+need-app = true
+
+disable-logging = true               ; Disable built-in logging 
+log-4xx = true                       ; but log 4xx's anyway
+log-5xx = true                       ; and 5xx's
+
+py-callos-afterfork = true           ; allow workers to trap signals
+
+max-requests = 1000                  ; Restart workers after this many requests
+max-worker-lifetime = 3600           ; Restart workers after this many seconds
+worker-reload-mercy = 60             ; How long to wait before forcefully killing workers
 
 # algorithm to scale automatically:
 cheaper-algo = spare # set cheaper algorithm to use, if not set default will be used
@@ -32,3 +45,4 @@ cheaper = 2          # minimum number of workers to keep at all times
 cheaper-initial = 3  # number of workers to spawn at startup
 workers = 16         # maximum number of workers that can be spawned
 cheaper-step = 1     # how many workers should be spawned at a time
+

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -26,18 +26,18 @@ module =kolibri.deployment.default.wsgi:application
 buffer-size = 8192  # needed to support long requests blocks (in lessons, for example)
 wsgi-disable-file-wrapper = true  # needed to fix uwsgi bug https://github.com/unbit/uwsgi/issues/1126
 single-interpreter = true
-die-on-term = true                   ; Shutdown when receiving SIGTERM (default is respawn)
+die-on-term = true                   # Shutdown when receiving SIGTERM (default is respawn)
 need-app = true
 
-disable-logging = true               ; Disable built-in logging 
-log-4xx = true                       ; but log 4xx's anyway
-log-5xx = true                       ; and 5xx's
+disable-logging = true               # Disable built-in logging
+log-4xx = true                       # but log 4xx's anyway
+log-5xx = true                       # and 5xx's
 
-py-callos-afterfork = true           ; allow workers to trap signals
+py-callos-afterfork = true           # allow workers to trap signals
 
-max-requests = 1000                  ; Restart workers after this many requests
-max-worker-lifetime = 3600           ; Restart workers after this many seconds
-worker-reload-mercy = 60             ; How long to wait before forcefully killing workers
+max-requests = 1000                  # Restart workers after this many requests
+max-worker-lifetime = 3600           # Restart workers after this many seconds
+worker-reload-mercy = 60             # How long to wait before forcefully killing workers
 
 # algorithm to scale automatically:
 cheaper-algo = spare # set cheaper algorithm to use, if not set default will be used


### PR DESCRIPTION
After investigating deeply #51 , there were several reasons for the service to timeout:
- Using service to start/stop/restart kolibri was delaying everything because systemd configuration for kolibri has a `TimeoutStartSec=infinity` setup
- Sometimes the pid and sockets for uwsgi were not correctly deleted
- kolibri-server systemd was more complex than needed

This PR:
- Uses the same commands the kolibri daemon uses to start it, but without depending on systemctl
- Optimizes uwsgi configuration
- Optimizes systemd configuration
- Ensures any leftover socket and pid for uwsgi is removed before starting


Close #51 
Cancels #50 
