### PR TITLE
Adds a convenient "make dist" target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+debian/files

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
+# Build artifacts
 debian/files
+debian/.debhelper
+debian/*debhelper*
+debian/kolibri-server.substvars
+debian/kolibri-server/

--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,12 @@
-.PHONY: help clean translations dist config-nginx
+.PHONY: help translations dist config-nginx orig
 
 help:
 	@echo "translations - download available crowdin translations"
 	@echo "release - prepare a release"
 	@echo "dist - package"
+	@echo "orig - creates ../kolibri-server_n.n.n.orig.tar.gz"
 	@echo $(shell dpkg-parsechangelog -SVersion)
+
 translations:
 	@echo "Ensure to set the project crowdin api in env variable called CROWDIN_API_KEY"
 	@echo "Also remember the project must have been built in crowdin to have the changes applied"
@@ -16,5 +18,13 @@ translations:
 release: translations
 	dch -i
 
-dist:
+dist: orig
 	dpkg-buildpackage -S
+
+# Solution from: https://stackoverflow.com/a/43145972/405682
+VERSION:=$(shell dpkg-parsechangelog -S Version | sed -rne 's,([^-\+]+)+(\+dfsg)*.*,\1,p'i)
+UPSTREAM_PACKAGE:=kolibri-server_${VERSION}.orig.tar.gz
+orig:
+	@echo "Creating .orig tarball: ../${UPSTREAM_PACKAGE}"
+	tar caf ../${UPSTREAM_PACKAGE} . --exclude debian --exclude .git
+	debuild -uc -us

--- a/README.rst
+++ b/README.rst
@@ -23,6 +23,18 @@ You can optimize this workflow according to your own needs.
 
 Changes can be built and released in ``kolibri-proposed`` by the `Learning Equality Launchpad team <https://launchpad.net/~learningequality/>`__.
 
+Working in the repo
+-------------------
+
+You can also make changes in the cloned repository in the following workflow:
+
+1. Make your changes
+1. Run `dch`, carefully noting your release notes
+1. Build the package with `make dist`
+1. Test the package with  `sudo dpkg -i ../kolibri-server_VERSION.deb`
+1. If you have further changes, you can keep editing and invoking `make dist`
+1. Finally, commit your changes and open a PR, including your entry in `debian/changelog`
+
 Releasing
 ---------
 


### PR DESCRIPTION
Kept running into this

```
This package has a Debian revision number but there does not seem to be
an appropriate original tar file or .orig directory in the parent directory;
(expected one of kolibri-server_0.3.6.orig.tar.gz, kolibri-server_0.3.6.orig.tar.bz2,
kolibri-server_0.3.6.orig.tar.lzma,  kolibri-server_0.3.6.orig.tar.xz or kolibri-server.orig)
continue anyway? (y/n) 
```