### PR TITLE
Make changes to be a native package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,12 +19,12 @@ release: translations
 	dch -i
 
 dist: orig
-	dpkg-buildpackage -S
+	dpkg-buildpackage -S -us -uc
 
 # Solution from: https://stackoverflow.com/a/43145972/405682
 VERSION:=$(shell dpkg-parsechangelog -S Version | sed -rne 's,([^-\+]+)+(\+dfsg)*.*,\1,p'i)
 UPSTREAM_PACKAGE:=kolibri-server_${VERSION}.orig.tar.gz
 orig:
 	@echo "Creating .orig tarball: ../${UPSTREAM_PACKAGE}"
-	tar caf ../${UPSTREAM_PACKAGE} . --exclude debian --exclude .git
+	tar caf ../${UPSTREAM_PACKAGE} .  --exclude .git
 	debuild -uc -us

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kolibri-server (0.3.7~beta1-0ubuntu3) UNRELEASED; urgency=medium
+
+  * Build kolibri-server as a native package
+
+ -- José L. Redrejo Rodríguez <jredrejo@debian.org>  Fri, 24 Apr 2020 17:17:03 +0200
+
 kolibri-server (0.3.7~beta1-0ubuntu2) bionic; urgency=medium
 
   * Use runuser instead of su (potential systemd issue) #54

--- a/debian/source/options
+++ b/debian/source/options
@@ -1,0 +1,1 @@
+tar-ignore = ".git"


### PR DESCRIPTION
Changes in Makefile to make kolibri-server a native package so building the package won't do a diff sources.

make dist
will create both the sources tar gz and build the deb, change and description files (unsigned)