### PR TITLE
Remove nginx symlink if needed

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,9 @@
-kolibri-server (0.3.7~beta1-0ubuntu3) UNRELEASED; urgency=medium
+kolibri-server (0.3.7~beta1-0ubuntu4) UNRELEASED; urgency=medium
 
   * Build kolibri-server as a native package
+  * If port 80 is selected when using debconf, remove default nginx symlink
 
- -- José L. Redrejo Rodríguez <jredrejo@debian.org>  Fri, 24 Apr 2020 17:17:03 +0200
+ -- José L. Redrejo Rodríguez <jredrejo@debian.org>  Mon, 27 Apr 2020 19:45:44 +0200
 
 kolibri-server (0.3.7~beta1-0ubuntu2) bionic; urgency=medium
 

--- a/debian/postinst
+++ b/debian/postinst
@@ -22,11 +22,14 @@ case "$1" in
     su $KOLIBRI_USER -c "/usr/share/kolibri-server/kolibri_server_setup.py -d $PORT"
     if [ -L "/etc/nginx/sites-enabled/default" ] && [ "$PORT" = "80" ] ;then
         rm  /etc/nginx/sites-enabled/default
-    elif [ ! -L "/etc/nginx/sites-enabled/default" ] && [ "$PORT" != "80" ] ;then
+        touch /etc/kolibri/nginx_default
+    elif [ ! -L "/etc/nginx/sites-enabled/default" ] && [ "$PORT" != "80" ]  && [ -f "/etc/kolibri/nginx_default" ] ;then
         ln -s /etc/nginx/sites-available/default /etc/nginx/sites-enabled/default
+        rm -f /etc/kolibri/nginx_default
     fi
     echo "include $DAEMON_HOME/nginx.conf;" > /etc/kolibri/nginx.d/099-user.conf
     service nginx reload || true
+    service kolibri-server force-reload || true
     ;;
   abort-upgrade|abort-remove|abort-deconfigure)
     ;;

--- a/debian/postinst
+++ b/debian/postinst
@@ -18,7 +18,13 @@ case "$1" in
     # create nginx configurations:
     ln -sf /etc/kolibri/dist/nginx.conf /etc/nginx/conf.d/kolibri.conf
     db_get kolibri-server/port
-    su $KOLIBRI_USER -c "/usr/share/kolibri-server/kolibri_server_setup.py -d $RET"
+    PORT=$RET
+    su $KOLIBRI_USER -c "/usr/share/kolibri-server/kolibri_server_setup.py -d $PORT"
+    if [ -L "/etc/nginx/sites-enabled/default" ] && [ "$PORT" = "80" ] ;then
+        rm  /etc/nginx/sites-enabled/default
+    elif [ ! -L "/etc/nginx/sites-enabled/default" ] && [ "$PORT" != "80" ] ;then
+        ln -s /etc/nginx/sites-available/default /etc/nginx/sites-enabled/default
+    fi
     echo "include $DAEMON_HOME/nginx.conf;" > /etc/kolibri/nginx.d/099-user.conf
     service nginx reload || true
     ;;

--- a/debian/postrm
+++ b/debian/postrm
@@ -5,6 +5,10 @@ case "$1" in
   remove|purge)
     rm -f /etc/nginx/conf.d/kolibri.conf
     rm -Rf /etc/kolibri/nginx.d
+    if [ ! -L "/etc/nginx/sites-enabled/default" ] && [ -f "/etc/kolibri/nginx_default" ] ;then
+        ln -s /etc/nginx/sites-available/default /etc/nginx/sites-enabled/default
+        rm -f /etc/kolibri/nginx_default
+    fi
     service nginx reload || true
     service kolibri restart || true
     ;;


### PR DESCRIPTION
If the user selects port 80 when configuring the package, the default symlink nginx has is removed. If another port is selected and the symlink does not exist, it is created.

Closes: #52 