### PR TITLE
System service knows if UWSGI fails, PID file owned by kolibri user

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,10 +1,12 @@
-kolibri-server (0.3.7~beta1-0ubuntu4) UNRELEASED; urgency=medium
+kolibri-server (0.3.8~beta1-0ubuntu1) UNRELEASED; urgency=medium
 
   [ José L. Redrejo Rodríguez ]
   * Build kolibri-server as a native package
   * If port 80 is selected when using debconf, remove default nginx symlink
 
   [ Benjamin Bach ]
+  * Silence startup error when redis cache is empty #63
+  * Move HTML error pages to /usr/share/kolibri/error_pages/ #70
   * Use --pidfile2 option for UWSGI #68
   * System service does not start if UWSGI does not start #68
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,7 +1,12 @@
 kolibri-server (0.3.7~beta1-0ubuntu4) UNRELEASED; urgency=medium
 
+  [ José L. Redrejo Rodríguez ]
   * Build kolibri-server as a native package
   * If port 80 is selected when using debconf, remove default nginx symlink
+
+  [ Benjamin Bach ]
+  * Use --pidfile2 option for UWSGI #68
+  * System service does not start if UWSGI does not start #68
 
  -- José L. Redrejo Rodríguez <jredrejo@debian.org>  Mon, 27 Apr 2020 19:45:44 +0200
 

--- a/debian/kolibri-server.init
+++ b/debian/kolibri-server.init
@@ -9,7 +9,10 @@
 # Description:       Multicore server setup for Kolibri, an offline education platform
 ### END INIT INFO
 
-# Do NOT "set -e"
+# Crash if a sub-process crashes. This is important to discover
+# errors in this script. It might be changed in the future.
+set -e
+
 # PATH should only include /usr/* if it runs after the mountnfs.sh script
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC="kolibri-server"
@@ -45,7 +48,7 @@ KOLIBRI_USER_HOME="$(getent passwd $KOLIBRI_USER | awk -F ':' '{print $6}')"
 DAEMON_HOME="$KOLIBRI_USER_HOME/.kolibri"
 
 DAEMON_UWSGI_ARGS="--ini /etc/kolibri/dist/uwsgi.ini --uid=$KOLIBRI_USER \
-  --env=KOLIBRI_HOME=$DAEMON_HOME --daemonize=$DAEMON_HOME/uwsgi.log --pidfile=$PIDFILE_UWSGI"
+  --env=KOLIBRI_HOME=$DAEMON_HOME --daemonize=$DAEMON_HOME/uwsgi.log --pidfile2=$PIDFILE_UWSGI"
 
 # Load the VERBOSE setting and other rcS variables
 . /lib/init/vars.sh

--- a/debian/kolibri-server.init
+++ b/debian/kolibri-server.init
@@ -9,9 +9,6 @@
 # Description:       Multicore server setup for Kolibri, an offline education platform
 ### END INIT INFO
 
-# Crash if a sub-process crashes. This is important to discover
-# errors in this script. It might be changed in the future.
-set -e
 
 # PATH should only include /usr/* if it runs after the mountnfs.sh script
 PATH=/sbin:/usr/sbin:/bin:/usr/bin
@@ -37,6 +34,10 @@ fi
 # Read configuration variable file if it is present
 [ -r $CONFIG_FILE ] || { echo "Configuration not found: $CONFIG_FILE" && exit 1 ;}
 [ -r $CONFIG_FILE ] && . $CONFIG_FILE
+
+# Crash if a sub-process crashes. This is important to discover
+# errors in this script. It might be changed in the future.
+set -e
 
 # Check that env vars were set after sourcing $CONFIG_FILE
 [ "$KOLIBRI_USER"=="" ] || { echo "$KOLIBRI_USER not set" && exit 1 ;}


### PR DESCRIPTION
Fixes #68 

@jredrejo I'm not sure if this is perfect, as the previous behavior could silently fail to start but also didn't send a SIGKILL to the `kolibri`

Adding an invalid option to trigger UWSGI failure now behaves like this:

```
test@kolibri-test:~$ sudo systemctl start kolibri-server
Job for kolibri-server.service failed because the control process exited with error code.
See "systemctl status kolibri-server.service" and "journalctl -xe" for details.
```

```
May 04 22:03:38 kolibri-test runuser[9111]: pam_unix(runuser:session): session opened for user test by (uid=0)
May 04 22:03:38 kolibri-test runuser[9111]: pam_unix(runuser:session): session closed for user test
May 04 22:03:38 kolibri-test kolibri-server[9117]: [uWSGI] getting INI configuration from /etc/kolibri/dist/uwsgi.ini
May 04 22:03:38 kolibri-test kolibri-server[9117]: /usr/bin/uwsgi: unrecognized option '--invalid-option'
May 04 22:03:38 kolibri-test kolibri-server[9117]: getopt_long() error
May 04 22:03:38 kolibri-test systemd[1]: kolibri-server.service: Control process exited, code=exited, status=2/INVALIDARGUMENT
May 04 22:03:38 kolibri-test systemd[1]: kolibri-server.service: Killing process 9096 (debconf-communi) with signal SIGKILL.
May 04 22:03:38 kolibri-test systemd[1]: kolibri-server.service: Killing process 9113 (kolibri) with signal SIGKILL.
May 04 22:03:38 kolibri-test systemd[1]: kolibri-server.service: Killing process 9096 (debconf-communi) with signal SIGKILL.
May 04 22:03:38 kolibri-test systemd[1]: kolibri-server.service: Killing process 9113 (kolibri) with signal SIGKILL.
May 04 22:03:38 kolibri-test systemd[1]: kolibri-server.service: Failed with result 'exit-code'.
May 04 22:03:38 kolibri-test systemd[1]: Failed to start A high performance web server setup for Kolibri.
```

![image](https://user-images.githubusercontent.com/374612/81018104-1d706380-8e64-11ea-927d-37d7dab1300e.png)
