### PR TITLE
Last polish

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,8 +1,10 @@
-kolibri-server (0.3.7-0ubuntu1) UNRELEASED; urgency=medium
+kolibri-server (0.3.7-0ubuntu1) bionic; urgency=low
 
   [ José L. Redrejo Rodríguez ]
   * Build kolibri-server as a native package
   * If port 80 is selected when using debconf, remove default nginx symlink
+  * Avoid error on uwsgi pid permissions
+  * Bump needed kolibri version to support redis options
 
   [ Benjamin Bach ]
   * Silence startup error when redis cache is empty #63
@@ -13,7 +15,7 @@ kolibri-server (0.3.7-0ubuntu1) UNRELEASED; urgency=medium
   * Adds a logrotate rule in /etc/logrotate.d/kolibri
   * Fix some syntax issues in init.d script
   * Use bash for init.d script
-  * Set GID of UWSGI process to same as UID's primary group  
+  * Set GID of UWSGI process to same as UID's primary group
 
  -- José L. Redrejo Rodríguez <jredrejo@debian.org>  Mon, 27 Apr 2020 19:45:44 +0200
 

--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Homepage: https://learningequality.org/kolibri
 Package: kolibri-server
 Architecture: all
 Recommends: anacron
-Depends: kolibri (>= 0.12.6), nginx-full, uwsgi (>= 2.0.12), uwsgi-plugin-python3, redis-server (>=4.0), python3 (>= 3.0)
+Depends: kolibri (>= 0.14.0), nginx-full, uwsgi (>= 2.0.12), uwsgi-plugin-python3, redis-server (>=4.0), python3 (>= 3.0)
 Enhances: kolibri
 Description: Improve Kolibri server network configuration
  This package automates uwsgi and nginx configuration for

--- a/debian/kolibri-server.init
+++ b/debian/kolibri-server.init
@@ -67,6 +67,8 @@ do_start()
   $SU_COMMAND $KOLIBRI_USER -c "/usr/share/kolibri-server/kolibri_server_setup.py"
   # ensure kolibri application is running:
   do_check_nginx
+  # ensure PIDFILE_UWSGI is not a world-writable pidfile
+  chmod 660 $PIDFILE_UWSGI || true
   $SU_COMMAND $KOLIBRI_USER -c "$KOLIBRI_COMMAND start &"
   mkdir -p /var/run/$NAME
   chown "$KOLIBRI_USER" /var/run/$NAME

--- a/debian/rules
+++ b/debian/rules
@@ -9,8 +9,7 @@ override_dh_systemd_enable:
 override_dh_compress:
 	for file in $$(cd nginx_error_page/ && find -name "error.html" -printf '%P\n'); do \
 		mkdir -p $(CURDIR)/debian/kolibri-server/usr/share/kolibri/error_pages/$$(dirname $$file); \
-		# Substitute magic string "1.2.3" for the actual version
 		sed 's/1.2.3/$(shell dpkg-parsechangelog -SVersion)/' \
-		  nginx_error_page/$$file > $(CURDIR)/debian/kolibri-server/usr/share/kolibri/error_pages/$$file;\
+		nginx_error_page/$$file > $(CURDIR)/debian/kolibri-server/usr/share/kolibri/error_pages/$$file;\
 	done
 	dh_compress


### PR DESCRIPTION
Before doing a release to fully support kolibri 0.14.x

- [x] Setup max memory usage on redis
- [x] Update changelog
- [x] Fix error due to bad permissions on uwsgi pid
- [x] Update debian/control for kolibri 0.14.x
- [x]  Fix error on debian/rules