### PR TITLE
export KOLIBRI_INSTALLATION_TYPE

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-kolibri-server (0.4.0~beta2-0ubuntu1) bionic; urgency=medium
+kolibri-server (0.4.0-0ubuntu1) bionic; urgency=medium
 
   * export KOLIBRI_INSTALLATION_TYPE for kolibri stats
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kolibri-server (0.4.0~beta2-0ubuntu1) bionic; urgency=medium
+
+  * export KOLIBRI_INSTALLATION_TYPE for kolibri stats
+
+ -- José L. Redrejo Rodríguez <jredrejo@debian.org>  Wed, 24 Nov 2021 19:53:34 +0100
+
 kolibri-server (0.4.0~beta1-0ubuntu1) bionic; urgency=low
 
   * New upstream release, compatible with kolibri 0.15.x

--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ Homepage: https://learningequality.org/kolibri
 Package: kolibri-server
 Architecture: all
 Recommends: anacron
-Depends: kolibri (>= 0.15.0), nginx-full, uwsgi (>= 2.0.12), uwsgi-plugin-python3, redis-server (>=4.0), python3 (>= 3.0)
+Depends: kolibri (>= 0.15.0~beta1), nginx-full, uwsgi (>= 2.0.12), uwsgi-plugin-python3, redis-server (>=4.0), python3 (>= 3.0)
 Enhances: kolibri
 Description: Improve Kolibri server network configuration
  This package automates uwsgi and nginx configuration for

--- a/debian/kolibri-server.init
+++ b/debian/kolibri-server.init
@@ -62,6 +62,8 @@ DAEMON_HASHI_UWSGI_ARGS="--ini /etc/kolibri/dist/hashi_uwsgi.ini --uid=$KOLIBRI_
 # and status_of_proc is working.
 . /lib/lsb/init-functions
 
+export KOLIBRI_INSTALLATION_TYPE="kolibriserver"
+
 do_start()
 {
   # Return


### PR DESCRIPTION
Exports  KOLIBRI_INSTALLATION_TYPE= env var set to "kolibriserver" for kolibri > 0.15 better handling of installer detection and stats
Closes: #85 

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1201425094255466