### PR TITLE
kolibri 0.15 has a services flag to start

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kolibri-server (0.4.0-0ubuntu2) bionic; urgency=high
+
+  * Fix daemon to start services correctly
+
+ -- José L. Redrejo Rodríguez <jredrejo@debian.org>  Tue, 30 Nov 2021 20:09:32 +0100
+
 kolibri-server (0.4.0-0ubuntu1) bionic; urgency=medium
 
   * export KOLIBRI_INSTALLATION_TYPE for kolibri stats

--- a/debian/kolibri-server.init
+++ b/debian/kolibri-server.init
@@ -77,7 +77,7 @@ do_start()
   # ensure PIDFILE_UWSGI is not a world-writable pidfile
   chmod 660 $PIDFILE_UWSGI || true
   chmod 660 $PIDFILE_UWSGI_HASHI || true
-  $SU_COMMAND $KOLIBRI_USER -c "$KOLIBRI_COMMAND start &"
+  $SU_COMMAND $KOLIBRI_USER -c "$KOLIBRI_COMMAND services &"
   mkdir -p /var/run/$NAME
   chown "$KOLIBRI_USER" /var/run/$NAME
   start-stop-daemon --start --quiet --exec $DAEMON_UWSGI --test -- $DAEMON_UWSGI_ARGS > /dev/null \
@@ -118,7 +118,7 @@ do_check_nginx()
       service nginx reload
   else
       $SU_COMMAND $KOLIBRI_USER -c "$KOLIBRI_COMMAND stop"
-      $SU_COMMAND $KOLIBRI_USER -c "$KOLIBRI_COMMAND start"
+      $SU_COMMAND $KOLIBRI_USER -c "$KOLIBRI_COMMAND services"
       service nginx start
   fi
 }


### PR DESCRIPTION
Ensure services are started. New 0.15 version does use a `services` param instead of setting the `CHERRYPY_START`  option

Closes: #90 