### PR TITLE
Fixes timeout error during start

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+kolibri-server (0.4.0-0ubuntu3) bionic; urgency=medium
+
+  * Fix timeout parameter to prevent failed start
+
+ -- Shrenik Bhura <shrenik.bhura@gmail.com>  Wed, 19 Jan 2022 16:10:32 +0530
+
 kolibri-server (0.4.0-0ubuntu2) bionic; urgency=high
 
   * Fix daemon to start services correctly

--- a/debian/kolibri-server.service
+++ b/debian/kolibri-server.service
@@ -11,6 +11,7 @@ Type=forking
 ExecStart=/etc/init.d/kolibri-server start
 ExecStop=/etc/init.d/kolibri-server stop
 KillMode=mixed
+TimeoutStartSec=infinity
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
- gives enough time for Kolibri startup processes to complete 
[learningequality/kolibri-server#92]