### PR TITLE
Ensure options.ini exists before attempting to back it up

### DIFF
--- a/.github/workflows/installtest.yml
+++ b/.github/workflows/installtest.yml
@@ -1,0 +1,40 @@
+name: Test installation of kolibri-server
+
+on:
+  push:
+    branches:
+    - master
+    tags:
+    - 'v*'
+  pull_request:
+
+jobs:
+  install_test:
+    name: Run installation of kolibri-server in docker image
+    runs-on: ubuntu-latest
+    strategy:
+      max-parallel: 5
+      matrix:
+        target-image: [ 'ubuntu:20.04', 'ubuntu:22.04', 'debian:bullseye', 'debian:bookworm' ]
+    steps:
+    - name: Checkout codebase
+      uses: actions/checkout@v4
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Run installation on ${{ matrix.target-image }}
+      uses: docker/build-push-action@v6
+      with:
+        build-args: |
+          TARGET_IMAGE=${{ matrix.target-image }}
+        context: ./
+        file: ./test/Dockerfile
+        platforms: linux/amd64,linux/arm64v8
+        push: false
+        target: test
+
+

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,8 @@ debian/*debhelper*
 debian/kolibri-server.substvars
 debian/kolibri-server/
 error_pages/
+
+# IDE
+.idea
+/*.iml
+.vscode

--- a/.tarignore
+++ b/.tarignore
@@ -1,0 +1,8 @@
+.git
+.github
+.gitignore
+.idea
+.tarignore
+.vscode
+*.iml
+test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help error-pages dist config-nginx orig
+.PHONY: help error-pages deb dist config-nginx orig
 
 help:
 	@echo "changelog - prepare debian/chanelog file with the new version number"
@@ -17,6 +17,9 @@ changelog:
 
 release: changelog  error-pages orig
 
+deb: orig
+	dpkg-buildpackage -b -us -uc
+
 dist: orig
 	dpkg-buildpackage -S -us -uc
 
@@ -25,4 +28,4 @@ VERSION:=$(shell dpkg-parsechangelog -S Version | sed -rne 's,([^-\+]+)+(\+dfsg)
 UPSTREAM_PACKAGE:=kolibri-server_${VERSION}.orig.tar.gz
 orig:
 	@echo "Creating .orig tarball: ../${UPSTREAM_PACKAGE}"
-	@tar --exclude=".git" -czf ../${UPSTREAM_PACKAGE} -C .. $(notdir $(CURDIR))
+	@tar --exclude-from=.tarignore -czf ../${UPSTREAM_PACKAGE} -C .. $(notdir $(CURDIR))

--- a/README.rst
+++ b/README.rst
@@ -61,3 +61,10 @@ Configuration
 You can configure the behavior of the UWSGI workers, by adding ``.ini`` files to ``/etc/kolibri/uwsgi.d/``.
 
 You can configure the main Nginx site and overwrite defaults by adding ``.conf`` files in to ``/etc/kolibri/nginx.d/``.
+
+Testing
+-------
+
+To run a build and installation test, you can use the following command to do so with docker::
+
+  docker build --build-arg TARGET_IMAGE=ubuntu:22.04 -f test/Dockerfile --target test .

--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ You can also make changes in the cloned repository in the following workflow:
 
 #. Make your changes
 #. Run ``dch``, carefully noting your release notes. 
-#. Build the package with ``make dist``
+#. Build the package with ``make deb``
 #. Test the package with  ``sudo dpkg -i ../kolibri-server_VERSION.deb``
 #. If you have further changes, you can keep editing and invoking ``make dist``
 #. Finally, commit your changes and open a PR, including your entry in ``debian/changelog``

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+kolibri-server (0.5.0-0ubuntu2) jammy; urgency=medium
+
+  * Addresses issue attempting to copy Kolibri options.ini prior to
+    initialization 
+
+ -- Blaine <blaine@learningequality.org>  Wed, 05 Mar 2025 11:47:19 -0800
+
 kolibri-server (0.5.0-0ubuntu1) jammy; urgency=medium
 
   * kolibri_server_setup.py : local nginx conf error pages changes

--- a/debian/postinst
+++ b/debian/postinst
@@ -18,12 +18,16 @@ case "$1" in
 
     if which runuser > /dev/null
     then
-      SU_COMMAND="runuser"
+        SU_COMMAND="runuser"
     else
-      SU_COMMAND="su"
+        SU_COMMAND="su"
     fi
-    # do a backup of the previous options.ini
-    if [ ! -e "$KOLIBRI_HOME/options.ini.kolibri-server-backup" ]; then
+
+    if [ ! -e "$KOLIBRI_HOME/options.ini" ]; then
+        # initialize Kolibri and the options.ini file
+        $SU_COMMAND $KOLIBRI_USER -w KOLIBRI_HOME -c "kolibri configure setup"
+    elif [ ! -e "$KOLIBRI_HOME/options.ini.kolibri-server-backup" ]; then
+        # do a backup of the previous options.ini
         $SU_COMMAND $KOLIBRI_USER -c "cp -f $KOLIBRI_HOME/options.ini $KOLIBRI_HOME/options.ini.kolibri-server-backup"
     fi
 
@@ -34,6 +38,7 @@ case "$1" in
     db_get kolibri-server/zip_content_port
     ZIPCONTENTPORT=$RET
     $SU_COMMAND $KOLIBRI_USER -c "/usr/share/kolibri-server/kolibri_server_setup.py -d $PORT -z $ZIPCONTENTPORT"
+
     if [ -L "/etc/nginx/sites-enabled/default" ] && [ "$PORT" = "80" ] ;then
         rm  /etc/nginx/sites-enabled/default
         touch /etc/kolibri/nginx_default
@@ -47,18 +52,18 @@ case "$1" in
     LOGROTATE_CONF="/etc/logrotate.d/kolibri"
     if [ -e "/etc/logrotate.d" ] # && ! [ -e "$LOGROTATE_CONF" ]
     then
-      # Issues with string substitution for "\n" caused this pattern
-      echo "\"${KOLIBRI_HOME}/logs/uwsgi.log\" {" > "$LOGROTATE_CONF"
-      echo "  copytruncate" >> "$LOGROTATE_CONF"
-      echo "  weekly" >> "$LOGROTATE_CONF"
-      echo "  rotate 150" >> "$LOGROTATE_CONF"
-      echo "  size 2M" >> "$LOGROTATE_CONF"
-      echo "  compress" >> "$LOGROTATE_CONF"
-      echo "  delaycompress" >> "$LOGROTATE_CONF"
-      echo "  missingok" >> "$LOGROTATE_CONF"
-      echo "  notifempty" >> "$LOGROTATE_CONF"
-      echo "  create 0644 $KOLIBRI_USER $KOLIBRI_GROUP" >> "$LOGROTATE_CONF"
-      echo "}" >> "$LOGROTATE_CONF"
+        # Issues with string substitution for "\n" caused this pattern
+        echo "\"${KOLIBRI_HOME}/logs/uwsgi.log\" {" > "$LOGROTATE_CONF"
+        echo "  copytruncate" >> "$LOGROTATE_CONF"
+        echo "  weekly" >> "$LOGROTATE_CONF"
+        echo "  rotate 150" >> "$LOGROTATE_CONF"
+        echo "  size 2M" >> "$LOGROTATE_CONF"
+        echo "  compress" >> "$LOGROTATE_CONF"
+        echo "  delaycompress" >> "$LOGROTATE_CONF"
+        echo "  missingok" >> "$LOGROTATE_CONF"
+        echo "  notifempty" >> "$LOGROTATE_CONF"
+        echo "  create 0644 $KOLIBRI_USER $KOLIBRI_GROUP" >> "$LOGROTATE_CONF"
+        echo "}" >> "$LOGROTATE_CONF"
     fi
 
     service nginx reload || true

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,0 +1,55 @@
+ARG TARGET_IMAGE=ubuntu:22.04
+FROM ${TARGET_IMAGE} AS base
+
+RUN apt-get update && apt-get install -y gpg tzdata
+
+# set timezone to New York
+RUN rm /etc/localtime && \
+    ln -s /usr/share/zoneinfo/America/New_York /etc/localtime && \
+    dpkg-reconfigure -f noninteractive tzdata
+
+ENV TZ=America/New_York
+
+COPY --chmod=755 test/setup_ppa.sh setup_ppa.sh
+RUN ./setup_ppa.sh
+
+# set options to skip interactive configuration
+RUN echo "kolibri kolibri/init boolean false" | debconf-set-selections; \
+    echo "kolibri kolibri/user string kolibri" | debconf-set-selections
+
+RUN mkdir -p /app/kolibri-server
+WORKDIR /app/kolibri-server
+
+
+FROM base AS build
+
+RUN apt-get update && apt-get install -y devscripts debhelper dpkg-dev
+
+COPY .tarignore .tarignore
+COPY debian debian
+COPY Makefile Makefile
+COPY README.rst README.rst
+COPY dist_README dist_README
+COPY hashi_uwsgi.ini hashi_uwsgi.ini
+COPY kolibri_server_setup.py kolibri_server_setup.py
+COPY nginx.conf nginx.conf
+COPY nginx.d_README nginx.d_README
+COPY ppa-copy-packages.py ppa-copy-packages.py
+COPY uwsgi.d_README uwsgi.d_README
+COPY uwsgi.ini uwsgi.ini
+
+RUN apt update && apt install -y kolibri
+
+RUN make error-pages && make deb
+
+
+FROM base AS test
+
+# set options to skip interactive configuration
+RUN echo "kolibri-server kolibri-server/port select 8080" | debconf-set-selections; \
+    echo "kolibri-server kolibri-server/zip_content_port select 8081" | debconf-set-selections
+
+COPY --from=build /app/kolibri-server_*.deb /app/kolibri-server.deb
+
+RUN apt update && apt install -y /app/kolibri-server.deb
+

--- a/test/setup_ppa.sh
+++ b/test/setup_ppa.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
+gpg --output /usr/share/keyrings/learningequality-kolibri.gpg --export  DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
+
+echo "deb [signed-by=/usr/share/keyrings/learningequality-kolibri.gpg] http://ppa.launchpad.net/learningequality/kolibri/ubuntu jammy main" \
+  > /etc/apt/sources.list.d/learningequality-ubuntu-kolibri.list


### PR DESCRIPTION
<!--
 1. Following guidance below, replace …'s with your own words
 2. After saving the PR, tick of completed checklist items
 3. Skip checklist items that are not applicable or not necessary
 4. Delete instruction/comment blocks
-->

## Summary
<!--
 * description of the change
 * manual verification steps performed
 * screenshots if the PR affects the UI
-->
- Skips the backing up of `options.ini` if it doesn't exist, and instead runs `kolibri configure setup` to generate it
- Updates tooling to allow building `.deb` like the README mentions
- Adds a docker based installation test and Github workflow for it


