### PR TITLE
Fix unsupported --output-directory in dist target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,8 @@ deb: error-pages orig
 dist: error-pages orig
 	@mkdir -p dist
 	echo "Building unsigned package..."
-	dpkg-buildpackage -S -us -uc --output-directory=dist/
+	dpkg-buildpackage -S -us -uc
+	mv ../kolibri-server_$(VERSION)* dist/
 	@echo "Package built successfully!"
 # build and sign (signing uses environment GPG_PASSPHRASE and KEYID)
 sign-and-upload: dist


### PR DESCRIPTION
## Summary

- `dpkg-buildpackage --output-directory` requires dpkg 1.22+ but the CI runner has an older version
- Build to the default parent directory and move files into `dist/` instead

## References

Fixes the `build_debian` workflow failure after #114.

## Reviewer guidance

One-line change in the Makefile `dist` target — low risk.

## AI usage

Claude Code identified and fixed the incompatible flag.