### PR TITLE
fix: correct extend-diff-ignore regex for dpkg-source

### DIFF
--- a/.tarignore
+++ b/.tarignore
@@ -5,4 +5,7 @@
 .tarignore
 .vscode
 *.iml
+*.egg-info
+__pycache__
+.venv
 test

--- a/debian/source/options
+++ b/debian/source/options
@@ -1,1 +1,2 @@
 tar-ignore = ".git"
+extend-diff-ignore = "^(\.github|\.gitignore|\.tarignore|\.idea|\.vscode|test)(/|$)|\.iml$"


### PR DESCRIPTION
## Summary

- Fix `extend-diff-ignore` regex in `debian/source/options` so `dpkg-source` correctly ignores files excluded from the orig tarball via `.tarignore` (`.github/`, `test/`, `.gitignore`, `.tarignore`, IDE files)
- Add `.venv`, `*.egg-info`, and `__pycache__` to `.tarignore` to prevent local dev artifacts from leaking into the orig tarball

## Context

After merging #114 and #115, `build_debian.yml` was failing because `dpkg-source` detected "unexpected upstream changes" — files present in the working tree but excluded from the orig tarball by `.tarignore`. The previous regex `^[^/]*/(...)/? ` was wrong; file paths don't have a directory prefix.

## Test plan

- [x] Verified locally: `dpkg-buildpackage -S -us -uc` succeeds in a clean ubuntu:latest container
- [ ] CI `build_debian.yml` passes on next release

🤖 Generated with [Claude Code](https://claude.com/claude-code)