### PR TITLE
fix: dynamic series detection and debsign

### DIFF
--- a/.github/workflows/build_debian.yml
+++ b/.github/workflows/build_debian.yml
@@ -43,6 +43,11 @@ jobs:
     steps:
       - name: checkout codebase
         uses: actions/checkout@v4
+      - name: Set changelog distribution to runner series
+        run: |
+          SERIES=$(. /etc/os-release && echo "$VERSION_CODENAME")
+          sed -i "1s/) [a-z]*;/) ${SERIES};/" debian/changelog
+          echo "Targeting series: ${SERIES}"
       - name: Install build and upload dependencies
         run: make install-upload-deps
       - name: Install Kolibri
@@ -68,6 +73,8 @@ jobs:
         if: steps.check_source.outputs.already_uploaded != 'true'
         run: |
           echo -n "${{ secrets.GPG_SIGNING_KEY }}" | base64 --decode | gpg --import --no-tty --batch --yes
+          echo "allow-loopback-pinentry" >> ~/.gnupg/gpg-agent.conf
+          gpgconf --kill gpg-agent
       - name: Sign and upload package
         if: steps.check_source.outputs.already_uploaded != 'true'
         env:
@@ -119,7 +126,7 @@ jobs:
           LP_CREDENTIALS: ${{ secrets.LP_CREDENTIALS }}
         run: |
           echo "$LP_CREDENTIALS" > /tmp/lp-creds.txt
-      - name: Copy from jammy to supported series
+      - name: Copy to other supported series
         env:
           LP_CREDENTIALS_FILE: /tmp/lp-creds.txt
         run: |

--- a/.github/workflows/installtest.yml
+++ b/.github/workflows/installtest.yml
@@ -10,9 +10,17 @@ jobs:
   build:
     name: Build kolibri-server .deb package
     runs-on: ubuntu-latest
+    outputs:
+      ppa_series: ${{ steps.detect_series.outputs.PPA_SERIES }}
     steps:
       - name: Checkout codebase
         uses: actions/checkout@v4
+      - name: Detect runner series
+        id: detect_series
+        run: |
+          SERIES=$(. /etc/os-release && echo "$VERSION_CODENAME")
+          echo "PPA_SERIES=${SERIES}" >> "$GITHUB_OUTPUT"
+          echo "Detected series: ${SERIES}"
       - name: Install build dependencies
         run: make install-build-deps
       - name: Install Kolibri
@@ -47,6 +55,8 @@ jobs:
           ln -s /usr/share/zoneinfo/America/New_York /etc/localtime
           dpkg-reconfigure -f noninteractive tzdata
       - name: Setup Kolibri PPA
+        env:
+          PPA_SERIES: ${{ needs.build.outputs.ppa_series }}
         run: ./test/setup_ppa.sh
       - name: Configure debconf selections
         run: |

--- a/Makefile
+++ b/Makefile
@@ -53,10 +53,13 @@ dist: error-pages orig
 	dpkg-buildpackage -S -us -uc
 	mv ../kolibri-server_$(VERSION)* dist/
 	@echo "Package built successfully!"
-# build and sign (signing uses environment GPG_PASSPHRASE and KEYID)
+# build and sign (signing uses environment GPG_KEY_ID and GPG_PASSPHRASE)
 sign-and-upload: dist
 	@echo "Signing and uploading package..."
-	debsign -p"gpg --batch --yes --pinentry-mode loopback --passphrase $(GPG_PASSPHRASE)" dist/*.changes
+	@printf '%s' "$$GPG_PASSPHRASE" > /tmp/.gpg-passphrase
+	debsign -p"gpg --batch --pinentry-mode loopback --passphrase-file /tmp/.gpg-passphrase" \
+		-k"$$GPG_KEY_ID" dist/*.changes
+	@rm -f /tmp/.gpg-passphrase
 	@echo "Uploading to PPA..."
 	dput --unchecked ppa:learningequality/kolibri-proposed dist/*.changes
 	@echo "Upload completed successfully!"

--- a/test/setup_ppa.sh
+++ b/test/setup_ppa.sh
@@ -5,9 +5,18 @@ set -e
 SUDO=""
 [ "$(id -u)" != "0" ] && SUDO="sudo"
 
+# Detect Ubuntu series for PPA source line
+# On Ubuntu: use the OS codename. On non-Ubuntu (e.g. Debian): require PPA_SERIES env var.
+. /etc/os-release
+if [ "$ID" = "ubuntu" ]; then
+  SERIES="$VERSION_CODENAME"
+else
+  SERIES="${PPA_SERIES:?PPA_SERIES must be set for non-Ubuntu systems (e.g. PPA_SERIES=noble)}"
+fi
+
 gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
 gpg --output /tmp/learningequality-kolibri.gpg --export DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81
 $SUDO mv /tmp/learningequality-kolibri.gpg /usr/share/keyrings/learningequality-kolibri.gpg
 
-echo "deb [signed-by=/usr/share/keyrings/learningequality-kolibri.gpg] http://ppa.launchpad.net/learningequality/kolibri/ubuntu jammy main" \
+echo "deb [signed-by=/usr/share/keyrings/learningequality-kolibri.gpg] http://ppa.launchpad.net/learningequality/kolibri/ubuntu $SERIES main" \
   | $SUDO tee /etc/apt/sources.list.d/learningequality-ubuntu-kolibri.list > /dev/null


### PR DESCRIPTION
## Summary

- **Dynamic series detection**: Replace hardcoded `jammy` everywhere with auto-detection from `/etc/os-release`. When `ubuntu-latest` moves to 26.04, everything transitions seamlessly.
- **Fix debsign signing**: Use `--passphrase-file` and `-k $GPG_KEY_ID` instead of broken `-p"gpg --passphrase $(MAKE_VAR)"` approach that mangled arguments.
- **Fix copy-to-series**: Was silently doing nothing because it looked for packages in `noble` (runner OS) but they were uploaded to `jammy` (changelog). Now the changelog distribution is patched to match the runner at build time.

## Changes

| File | What changed |
|------|-------------|
| `test/setup_ppa.sh` | Auto-detect Ubuntu series; require `PPA_SERIES` env var for Debian |
| `Makefile` | Fix `sign-and-upload`: `--passphrase-file`, `-k $$GPG_KEY_ID`, shell (`$$`) not Make (`$()`) expansion |
| `build_debian.yml` | Patch changelog distribution at build time; configure `allow-loopback-pinentry` |
| `installtest.yml` | Build job outputs detected series → test jobs pass it as `PPA_SERIES` |

## Test plan

- [x] `setup_ppa.sh` tested on Ubuntu container (auto-detects `noble`)
- [x] `setup_ppa.sh` tested on Debian container with `PPA_SERIES=noble`
- [x] `setup_ppa.sh` tested on Debian container without `PPA_SERIES` (errors with helpful message)
- [x] Changelog sed patching verified (`jammy` → `noble` on line 1 only)
- [x] `debsign` with `--passphrase-file` tested end-to-end with passphrase-protected key
- [ ] CI install tests pass
- [ ] `build_debian.yml` succeeds on next release (requires secrets)

🤖 Generated with [Claude Code](https://claude.com/claude-code)