### PR TITLE
fix: debsign argument parsing, PPA_SERIES precedence, passphrase cleanup

### DIFF
--- a/.github/workflows/build_debian.yml
+++ b/.github/workflows/build_debian.yml
@@ -81,9 +81,9 @@ jobs:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
           GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
         run: make sign-and-upload
-      - name: Cleanup Launchpad credentials
+      - name: Cleanup credentials
         if: always()
-        run: rm -f /tmp/lp-creds.txt
+        run: rm -f /tmp/lp-creds.txt /tmp/.gpg-passphrase
   wait_for_source_builds:
     needs:
       - check_version

--- a/Makefile
+++ b/Makefile
@@ -56,9 +56,11 @@ dist: error-pages orig
 # build and sign (signing uses environment GPG_KEY_ID and GPG_PASSPHRASE)
 sign-and-upload: dist
 	@echo "Signing and uploading package..."
+	@test -n "$$GPG_KEY_ID" || { echo "Error: GPG_KEY_ID is not set"; exit 1; }
+	@test -n "$$GPG_PASSPHRASE" || { echo "Error: GPG_PASSPHRASE is not set"; exit 1; }
 	@printf '%s' "$$GPG_PASSPHRASE" > /tmp/.gpg-passphrase
 	debsign -p"gpg --batch --pinentry-mode loopback --passphrase-file /tmp/.gpg-passphrase" \
-		-k"$$GPG_KEY_ID" dist/*.changes
+		-k "$$GPG_KEY_ID" dist/*.changes
 	@rm -f /tmp/.gpg-passphrase
 	@echo "Uploading to PPA..."
 	dput --unchecked ppa:learningequality/kolibri-proposed dist/*.changes

--- a/test/setup_ppa.sh
+++ b/test/setup_ppa.sh
@@ -6,12 +6,16 @@ SUDO=""
 [ "$(id -u)" != "0" ] && SUDO="sudo"
 
 # Detect Ubuntu series for PPA source line
-# On Ubuntu: use the OS codename. On non-Ubuntu (e.g. Debian): require PPA_SERIES env var.
+# PPA_SERIES env var takes precedence (used by CI to ensure all containers use the same series).
+# On Ubuntu without PPA_SERIES: auto-detect from OS. On non-Ubuntu: PPA_SERIES is required.
 . /etc/os-release
-if [ "$ID" = "ubuntu" ]; then
+if [ -n "${PPA_SERIES:-}" ]; then
+  SERIES="$PPA_SERIES"
+elif [ "$ID" = "ubuntu" ]; then
   SERIES="$VERSION_CODENAME"
 else
-  SERIES="${PPA_SERIES:?PPA_SERIES must be set for non-Ubuntu systems (e.g. PPA_SERIES=noble)}"
+  echo "Error: PPA_SERIES must be set for non-Ubuntu systems (e.g. PPA_SERIES=noble)" >&2
+  exit 1
 fi
 
 gpg --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys DC5BAA93F9E4AE4F0411F97C74F88ADB3194DD81


### PR DESCRIPTION
## Summary

Follow-up fixes for the debsign signing failure after merging #117:

- **Makefile**: Validate `GPG_KEY_ID` and `GPG_PASSPHRASE` are set before signing; space-separate `-k` from its value so an empty key ID doesn't consume the `.changes` filename as the key argument
- **setup_ppa.sh**: `PPA_SERIES` env var takes precedence when set, ensuring all CI containers (including Ubuntu ones) use the same PPA series
- **build_debian.yml**: Cleanup step also removes GPG passphrase temp file on failure

Full build+sign flow verified end-to-end in an ubuntu:latest container (changelog patching → install-upload-deps → install-kolibri → dist → debsign with passphrase-protected key).

## References

- Fixes the signing failure from #117
- Part of the broader CI refactor started in #114

## Reviewer guidance

- The debsign fix can be verified by checking that `-k "value"` (space-separated) won't collapse when the value is empty, unlike `-k"value"` which becomes just `-k`
- `setup_ppa.sh` change: `PPA_SERIES` now takes precedence over auto-detection, so CI containers consistently use the build runner's series
- The passphrase cleanup is a defense-in-depth measure for CI

## AI usage

This PR was developed using Claude Code. Claude identified the root cause of the debsign failure (empty `-k""` consuming the next positional argument), proposed and tested fixes, and ran a full end-to-end simulation of the build_debian.yml workflow in an ubuntu:latest container to verify the signing flow works with a passphrase-protected GPG key.