### PR TITLE
fix: extract GPG key ID from imported key

### DIFF
--- a/.github/workflows/build_debian.yml
+++ b/.github/workflows/build_debian.yml
@@ -75,11 +75,14 @@ jobs:
           echo -n "${{ secrets.GPG_SIGNING_KEY }}" | base64 --decode | gpg --import --no-tty --batch --yes
           echo "allow-loopback-pinentry" >> ~/.gnupg/gpg-agent.conf
           gpgconf --kill gpg-agent
+          # Extract key ID from imported key so we don't need a separate secret
+          GPG_KEY_ID=$(gpg --list-secret-keys --keyid-format long --with-colons | grep ^sec | head -1 | cut -d: -f5)
+          echo "GPG_KEY_ID=$GPG_KEY_ID" >> "$GITHUB_ENV"
+          echo "Imported GPG key: $GPG_KEY_ID"
       - name: Sign and upload package
         if: steps.check_source.outputs.already_uploaded != 'true'
         env:
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
-          GPG_KEY_ID: ${{ secrets.GPG_KEY_ID }}
         run: make sign-and-upload
       - name: Cleanup credentials
         if: always()


### PR DESCRIPTION
## Summary

The `GPG_KEY_ID` secret doesn't exist in the repo — only `GPG_SIGNING_KEY` and `GPG_PASSPHRASE` are configured. Extract the key ID automatically from the imported key using `gpg --list-secret-keys --with-colons` and pass it via `GITHUB_ENV` to the signing step.

## References

- Fixes signing failure in build_debian.yml after #117 / #119

## Reviewer guidance

Single-line change: after importing the GPG key, extract its ID using the machine-parseable `--with-colons` format (field 5 = key ID) and export via `GITHUB_ENV`. Removes the dependency on a `GPG_KEY_ID` secret.

## AI usage

Claude Code identified the missing secret and proposed extracting the key ID from the imported key. Verified the extraction command in an ubuntu:latest container.