### PR TITLE
fix: force orig tarball inclusion in source package upload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ deb: error-pages orig
 dist: error-pages orig
 	@mkdir -p dist
 	echo "Building unsigned package..."
-	dpkg-buildpackage -S -us -uc
+	dpkg-buildpackage -S -us -uc -sa
 	mv ../kolibri-server_$(VERSION)* dist/
 	@echo "Package built successfully!"
 # build and sign (signing uses environment GPG_KEY_ID and GPG_PASSPHRASE)


### PR DESCRIPTION
## Summary

Add `-sa` flag to `dpkg-buildpackage` so the `.orig.tar.gz` is always included in the upload. Without it, dpkg assumes the orig already exists on Launchpad (since `-0ubuntu2` isn't a first revision), but the noble upload has never succeeded so Launchpad silently rejects the package.

## References

- Fixes silent upload rejection following #120 / #119

## Reviewer guidance

One-character change: `-sa` flag on `dpkg-buildpackage`. Once the orig exists on Launchpad, this flag becomes a no-op (Launchpad deduplicates), so it's safe to keep permanently.

## AI usage

Claude Code identified the root cause from the `dpkg-genchanges: info: not including original source code in upload` log line — the orig tarball was missing from the upload because dpkg assumed it already existed on Launchpad.