### PR TITLE
fix: bump version to 0.5.1 for fresh Launchpad upload

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ deb: error-pages orig
 dist: error-pages orig
 	@mkdir -p dist
 	echo "Building unsigned package..."
-	dpkg-buildpackage -S -us -uc -sa
+	dpkg-buildpackage -S -us -uc
 	mv ../kolibri-server_$(VERSION)* dist/
 	@echo "Package built successfully!"
 # build and sign (signing uses environment GPG_KEY_ID and GPG_PASSPHRASE)

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,12 @@
-kolibri-server (0.5.0-0ubuntu2) jammy; urgency=medium
+kolibri-server (0.5.1-0ubuntu1) jammy; urgency=medium
 
   * Addresses issue attempting to copy Kolibri options.ini prior to
     initialization
+  * CI: extract setup steps into Makefile targets
+  * CI: rewrite install tests with native ARM runners
+  * CI: fix build workflow (dynamic series detection, GPG signing)
 
- -- Blaine <blaine@learningequality.org>  Wed, 05 Mar 2025 11:47:19 -0800
+ -- Blaine <blaine@learningequality.org>  Mon, 31 Mar 2026 12:00:00 -0800
 
 kolibri-server (0.5.0-0ubuntu1) jammy; urgency=medium
 


### PR DESCRIPTION
## Summary

The `0.5.0` orig tarball already exists on Launchpad (from the previous jammy upload) with different contents, so all uploads of `0.5.0-0ubuntu2` are silently rejected. Bump to `0.5.1-0ubuntu1` for a fresh orig tarball name.

Also reverts the `-sa` flag from #121 since a new upstream version automatically includes the orig.

## References

- Fixes Launchpad rejection: "File kolibri-server_0.5.0.orig.tar.gz already exists but uploaded version has different contents"
- Supersedes #121

## Reviewer guidance

- Changelog bump: `0.5.0-0ubuntu2` → `0.5.1-0ubuntu1`
- Makefile: reverts `-sa` (no longer needed with new upstream version)

## AI usage

Claude Code identified the Launchpad rejection cause from the email notification and proposed the version bump.