### PR TITLE
fix: remove functools.cache from methods receiving Launchpad Entry objects

### DIFF
--- a/scripts/launchpad_copy.py
+++ b/scripts/launchpad_copy.py
@@ -158,7 +158,6 @@ class LaunchpadWrapper:
         log.debug("Locating the series: %s...", name)
         return ppa.distribution.getSeries(name_or_version=name)
 
-    @functools.cache
     def get_published_sources(self, ppa, series_name=None, status=None):
         kwargs = {}
         if series_name:
@@ -169,7 +168,6 @@ class LaunchpadWrapper:
         log.debug("Listing source packages...")
         return ppa.getPublishedSources(**kwargs)
 
-    @functools.cache
     def get_builds_for_source(self, source):
         log.debug(
             "Listing %s builds for %s %s...",
@@ -179,7 +177,6 @@ class LaunchpadWrapper:
         )
         return source.getBuilds()
 
-    @functools.cache
     def get_source_packages(self, ppa, series_name, package_names=None):
         """Return {package_name: {version: source, ...}, ...}"""
         res = defaultdict(dict)
@@ -207,7 +204,6 @@ class LaunchpadWrapper:
         builds = self.get_builds_for(ppa, name, version, series_name)
         return not builds or builds[0].buildstate == "Successfully built"
 
-    @functools.cache
     def get_usable_sources(self, ppa, package_names, series_name):
         res = []
         for source in self.get_published_sources(ppa, series_name):

--- a/tests/test_launchpad_copy.py
+++ b/tests/test_launchpad_copy.py
@@ -240,7 +240,7 @@ class TestLaunchpadWrapper:
         src_bad.status = "Published"
 
         with patch.object(wrapper, "get_published_sources", return_value=[src_good, src_bad]):
-            result = LaunchpadWrapper.get_usable_sources.__wrapped__(wrapper, mock_ppa, ("kolibri-server",), "jammy")
+            result = wrapper.get_usable_sources(mock_ppa, ("kolibri-server",), "jammy")
 
         assert len(result) == 1
         assert result[0] == ("kolibri-server", "1.0")
@@ -255,7 +255,7 @@ class TestLaunchpadWrapper:
         src.status = "Superseded"
 
         with patch.object(wrapper, "get_published_sources", return_value=[src]):
-            result = LaunchpadWrapper.get_usable_sources.__wrapped__(wrapper, mock_ppa, ("kolibri-server",), "jammy")
+            result = wrapper.get_usable_sources(mock_ppa, ("kolibri-server",), "jammy")
 
         assert len(result) == 0
 


### PR DESCRIPTION
## Summary

`copy-to-series` crashes with `TypeError: unhashable type: 'Entry'` because several methods use `@functools.cache` but receive Launchpad `Entry` objects (PPAs, sources) which aren't hashable.

This never surfaced before because `copy-to-series` was silently finding no packages (wrong series bug). Now that it actually finds packages, it hits the cache decorator.

Removed `@functools.cache` from `get_published_sources`, `get_builds_for_source`, `get_source_packages`, and `get_usable_sources`. These are only called once per workflow run, so caching provides no benefit.

## References

- Fixes `copy_to_other_distributions` failure in build_debian.yml

## Reviewer guidance

Pure deletion of 4 `@functools.cache` decorators. The `@functools.cached_property` decorators on `lp`, `owner`, `proposed_ppa`, `release_ppa` are fine (no unhashable args). `get_series` is also fine (takes a string).

## AI usage

Claude Code identified the root cause from the traceback and removed the problematic cache decorators.