### PR TITLE
fix: has_published_binaries logic and no-binaries copy error

### DIFF
--- a/scripts/launchpad_copy.py
+++ b/scripts/launchpad_copy.py
@@ -202,7 +202,7 @@ class LaunchpadWrapper:
 
     def has_published_binaries(self, ppa, name, version, series_name):
         builds = self.get_builds_for(ppa, name, version, series_name)
-        return not builds or builds[0].buildstate == "Successfully built"
+        return bool(builds) and builds[0].buildstate == "Successfully built"
 
     def get_usable_sources(self, ppa, package_names, series_name):
         res = []
@@ -253,8 +253,11 @@ class LaunchpadWrapper:
                     source_names=sorted(names),
                 )
             except lre.BadRequest as e:
-                if "same version already published" in str(e):
+                msg = str(e)
+                if "same version already published" in msg:
                     log.info("Already copied to %s — skipping", target_series)
+                elif "has no binaries to be copied" in msg:
+                    log.warning("Binaries not yet published — skipping copy to %s", target_series)
                 else:
                     raise
 


### PR DESCRIPTION
## Summary

Two fixes for the `copy_to_other_distributions` failure:

- **`has_published_binaries`**: `not builds` returned `True` when no builds were found via API, treating "no builds" as "has binaries" and queuing the copy regardless. Fixed to require builds to exist AND be successful.
- **`perform_queued_copies`**: Handle Launchpad's "has no binaries to be copied" error gracefully as a warning instead of crashing.

## References

- Fixes: `lazr.restfulclient.errors.BadRequest: kolibri-server 0.5.1-0ubuntu1 in noble (source has no binaries to be copied)`

## Reviewer guidance

The `has_published_binaries` fix is the primary change — prevents copies from being queued when the API doesn't return build info. The error handler is defense-in-depth.

## AI usage

Claude Code identified the inverted boolean logic and the unhandled Launchpad error from CI logs.