### PR TITLE
ci: add GitHub Pages PPA and rename release workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly

--- a/.github/workflows/installtest.yml
+++ b/.github/workflows/installtest.yml
@@ -14,7 +14,7 @@ jobs:
       ppa_series: ${{ steps.detect_series.outputs.PPA_SERIES }}
     steps:
       - name: Checkout codebase
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Detect runner series
         id: detect_series
         run: |
@@ -30,7 +30,7 @@ jobs:
           make deb
           cp ../kolibri-server_*.deb ./kolibri-server.deb
       - name: Upload .deb artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: kolibri-server-deb
           path: kolibri-server.deb
@@ -46,7 +46,7 @@ jobs:
         runner: ['ubuntu-latest', 'ubuntu-24.04-arm']
     steps:
       - name: Checkout codebase
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup environment
         run: |
           apt-get update
@@ -65,7 +65,7 @@ jobs:
           echo "kolibri-server kolibri-server/port select 8080" | debconf-set-selections
           echo "kolibri-server kolibri-server/zip_content_port select 8081" | debconf-set-selections
       - name: Download .deb artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: kolibri-server-deb
       - name: Install kolibri-server

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -14,7 +14,7 @@ jobs:
       should_skip: ${{ steps.skip_check.outputs.should_skip }}
     steps:
       - id: skip_check
-        uses: fkirc/skip-duplicate-actions@master
+        uses: fkirc/skip-duplicate-actions@v5
         with:
           github_token: ${{ github.token }}
   linting:
@@ -23,6 +23,6 @@ jobs:
     if: ${{ needs.pre_job.outputs.should_skip != 'true' }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
       - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -8,7 +8,7 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Install system dependencies
         run: |
           sudo apt-get update

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -228,3 +228,77 @@ jobs:
       - name: Cleanup Launchpad credentials
         if: always()
         run: rm -f /tmp/lp-creds.txt
+  publish_github_pages_ppa:
+    name: Publish GitHub Pages PPA
+    needs:
+      - build_binary_package
+      - block_release_step
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
+    concurrency:
+      group: github-pages-deploy
+      cancel-in-progress: false
+    steps:
+      - name: Install reprepro
+        run: sudo apt-get update && sudo apt-get install -y reprepro
+      - name: Set GPG key ID
+        id: gpg
+        run: |
+          GPG_KEY_ID="${{ vars.DEBIAN_REPO_SIGNING_KEY_ID }}"
+          if [ -z "$GPG_KEY_ID" ]; then
+            echo "::error::No signing key ID provided (set vars.DEBIAN_REPO_SIGNING_KEY_ID)"
+            exit 1
+          fi
+          echo "key-id=$GPG_KEY_ID" >> "$GITHUB_OUTPUT"
+      - name: Import GPG signing key into isolated keyring
+        run: |
+          GNUPGHOME=$(mktemp -d)
+          export GNUPGHOME
+          echo "GNUPGHOME=$GNUPGHOME" >> "$GITHUB_ENV"
+          echo "pinentry-mode loopback" > "$GNUPGHOME/gpg.conf"
+          echo "allow-loopback-pinentry" > "$GNUPGHOME/gpg-agent.conf"
+          echo "${{ secrets.DEBIAN_REPO_SIGNING_KEY }}" | gpg --batch --import
+          echo "${{ steps.gpg.outputs.key-id }}:6:" | gpg --batch --import-ownertrust
+          gpgconf --kill gpg-agent
+      - name: Download .deb artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: kolibri-server-deb
+          path: incoming
+      - name: Identify .deb file
+        id: deb
+        run: |
+          DEB_FILE=$(find incoming -maxdepth 1 -name '*.deb' -print -quit)
+          if [ -z "$DEB_FILE" ]; then
+            echo "::error::No .deb file found in incoming/"
+            exit 1
+          fi
+          echo "path=$DEB_FILE" >> "$GITHUB_OUTPUT"
+          echo "Found: $DEB_FILE ($(du -h "$DEB_FILE" | cut -f1))"
+      - name: Build APT repository with reprepro
+        run: |
+          mkdir -p repo/conf
+          cat > repo/conf/distributions <<EOF
+          Origin: Learning Equality
+          Label: Kolibri Server
+          Suite: stable
+          Codename: stable
+          Architectures: amd64 i386 arm64 armhf
+          Components: main
+          Description: Kolibri Server Debian repository
+          SignWith: ${{ steps.gpg.outputs.key-id }}
+          EOF
+          reprepro -b repo includedeb stable "${{ steps.deb.outputs.path }}"
+          gpg --armor --export "${{ steps.gpg.outputs.key-id }}" > repo/pubkey.asc
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: repo
+      - name: Deploy to GitHub Pages
+        id: deploy
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
       version: ${{ steps.version.outputs.VERSION }}
     steps:
       - name: Checkout codebase
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Extract version from changelog
         id: changelog_version
         run: |
@@ -42,7 +42,7 @@ jobs:
     needs: check_version
     steps:
       - name: checkout codebase
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set changelog distribution to runner series
         run: |
           SERIES=$(. /etc/os-release && echo "$VERSION_CODENAME")
@@ -93,7 +93,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout codebase
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install build dependencies
         run: make install-build-deps
       - name: Install Kolibri
@@ -101,7 +101,7 @@ jobs:
       - name: Build .deb package
         run: make deb
       - name: Upload .deb artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: kolibri-server-deb
           path: ../kolibri-server_*.deb
@@ -112,7 +112,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout codebase
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -139,7 +139,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout codebase
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -164,7 +164,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout codebase
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -201,7 +201,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout codebase
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install dependencies
         run: |
           sudo apt-get update
@@ -266,7 +266,7 @@ jobs:
           echo "${{ steps.gpg.outputs.key-id }}:6:" | gpg --batch --import-ownertrust
           gpgconf --kill gpg-agent
       - name: Download .deb artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: kolibri-server-deb
           path: incoming
@@ -296,9 +296,9 @@ jobs:
           reprepro -b repo includedeb stable "${{ steps.deb.outputs.path }}"
           gpg --armor --export "${{ steps.gpg.outputs.key-id }}" > repo/pubkey.asc
       - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v4
         with:
           path: repo
       - name: Deploy to GitHub Pages
         id: deploy
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: Build Debian source package
+name: Release kolibri-server
 on:
   release:
     types: [published]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,6 +87,24 @@ jobs:
       - name: Cleanup credentials
         if: always()
         run: rm -f /tmp/lp-creds.txt /tmp/.gpg-passphrase
+  build_binary_package:
+    name: Build binary .deb for GitHub Pages PPA
+    needs: check_version
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout codebase
+        uses: actions/checkout@v4
+      - name: Install build dependencies
+        run: make install-build-deps
+      - name: Install Kolibri
+        run: make install-kolibri
+      - name: Build .deb package
+        run: make deb
+      - name: Upload .deb artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: kolibri-server-deb
+          path: ../kolibri-server_*.deb
   wait_for_source_published:
     needs:
       - check_version
@@ -168,7 +186,9 @@ jobs:
         run: rm -f /tmp/lp-creds.txt
   block_release_step:
     name: Job to block publish of a release until it has been manually approved
-    needs: wait_for_copies_published
+    needs:
+      - wait_for_copies_published
+      - build_binary_package
     runs-on: ubuntu-latest
     environment: release
     steps:


### PR DESCRIPTION
## Summary

Rename the release workflow from `build_debian.yml` to `release.yml` and add GitHub Pages PPA publishing alongside the existing Launchpad PPA. This lets Debian users install kolibri-server without relying on Launchpad's SHA-1 signed keys.

Two new jobs: `build_binary_package` builds a `.deb` in parallel with the Launchpad source upload, and `publish_github_pages_ppa` uses `reprepro` + `actions/deploy-pages` to publish an APT repository after the release approval gate.

## References

Related to the same fix applied in kolibri-installer-debian. That repo uses a gh-pages branch approach because the publish workflow is reusable across repos. Since this workflow only ever runs in this repository, we can use `actions/deploy-pages` directly, avoiding storing PPA state in git.

## Reviewer guidance

- This can be validated by re-running the release workflow via `workflow_dispatch` after configuring the required secrets/variable:
  - Secret: `DEBIAN_REPO_SIGNING_KEY` (shared from kolibri-installer-debian)
  - Variable: `DEBIAN_REPO_SIGNING_KEY_ID` (shared from kolibri-installer-debian)
  - GitHub Pages source set to "GitHub Actions" in repo settings
- The Launchpad jobs are unchanged — the new jobs run in parallel after the approval gate
- `publish_github_pages_ppa` at `.github/workflows/release.yml:231` is the main new job to review

## AI usage

This PR was authored collaboratively with Claude Code. The design was brainstormed iteratively, then implemented following a written plan. The workflow structure was modeled on kolibri-installer-debian's `publish_debian_repo.yml`, adapted to use `actions/deploy-pages`. All changes were validated with the repo's pre-commit hooks (yamlfmt, actionlint).